### PR TITLE
WINDUP-611  Add XSD to all rules, improve the namespace

### DIFF
--- a/rules-reviewed/jboss-eap/weblogic/weblogic.windup.xml
+++ b/rules-reviewed/jboss-eap/weblogic/weblogic.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="weblogic_rules_general">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="weblogic_rules_general"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
    <metadata>
       <description>
          This ruleset provides analysis of WebLogic proprietary classes and constructs that may require individual attention when migrating to JBoss EAP 6+.

--- a/rules/filemappings/default-package-to-organization-names.windup.xml
+++ b/rules/filemappings/default-package-to-organization-names.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="DefaultPackageToVendorNames">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="DefaultPackageToVendorNames"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <package-mapping from="bea" to="Weblogic"/>
     <package-mapping from="com\.bea" to="Weblogic"/>
     <package-mapping from="com\.weblogic" to="Weblogic"/>

--- a/rules/filemappings/file-mappings.windup.xml
+++ b/rules/filemappings/file-mappings.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlFileMappings">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlFileMappings"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
            <file-mapping from=".*\.tld$" to="XmlFileModel"/>
            <file-mapping from=".*\.bpel$" to="XmlFileModel"/>

--- a/rules/fuse/fuse-service-works/XmlSoaP5Rules.windup.xml
+++ b/rules/fuse/fuse-service-works/XmlSoaP5Rules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlSoa5Config">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlSoa5Config"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlSoa5Config_2fmb">
             <when>

--- a/rules/fuse/sonicesb/SonicESBRules.windup.xml
+++ b/rules/fuse/sonicesb/SonicESBRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="SonicESBConfig">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="SonicESBConfig"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <!--
         This ruleset contains rules that assist in migrating from Sonic ESB
         to Apache Camel.

--- a/rules/fuse/sonicesb/XmlSonicEsbRules.windup.xml
+++ b/rules/fuse/sonicesb/XmlSonicEsbRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlSonicEsbConfig">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlSonicEsbConfig"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlSonicEsbConfig_2fmb">
             <when>

--- a/rules/hibernate/LegacyToModernHibernateRules.windup.xml
+++ b/rules/hibernate/LegacyToModernHibernateRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="LegacyHibernateRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="LegacyHibernateRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="LegacyHibernateRules_2fmb">
             <when>

--- a/rules/hibernate/XmlOtherPersistenceToHibernateRules.windup.xml
+++ b/rules/hibernate/XmlOtherPersistenceToHibernateRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlToHibernateConfigMigrationRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlToHibernateConfigMigrationRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlToHibernateConfigMigrationRules_2fmb">
             <when>

--- a/rules/javaee/EjbRules.windup.xml
+++ b/rules/javaee/EjbRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="EjbRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="EjbRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="EjbRules_2fmb">
             <when>

--- a/rules/javaee/XmlEjbRules.windup.xml
+++ b/rules/javaee/XmlEjbRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlEjbRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlEjbRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlEjbRules_2fmb">
             <when>

--- a/rules/javaee/XmlSpringRules.windup.xml
+++ b/rules/javaee/XmlSpringRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlSpringRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlSpringRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlSpringRules_2fmb">
             <when>

--- a/rules/javaee/XmlWebServicesRules.windup.xml
+++ b/rules/javaee/XmlWebServicesRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlWebserviceRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlWebserviceRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlWebserviceRules_2fmb">
             <when>

--- a/rules/javaee/seam/SeamToCDI.windup.xml
+++ b/rules/javaee/seam/SeamToCDI.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="SeamToCDIRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="SeamToCDIRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="SeamToCDIRules_2fmb">
             <when>

--- a/rules/javaee/webservices.windup.xml
+++ b/rules/javaee/webservices.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="WebServicesIdentification">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="WebServicesIdentification"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="WebServicesIdentification_2fmb">
             <when>

--- a/rules/jboss-eap/JBossRules.windup.xml
+++ b/rules/jboss-eap/JBossRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="JBoss5Rules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="JBoss5Rules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="JBoss5Rules_2fmb">
             <when>

--- a/rules/jboss-eap/XmlJBoss5Rules.windup.xml
+++ b/rules/jboss-eap/XmlJBoss5Rules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlJBoss5Rules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlJBoss5Rules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlJBoss5Rules_2fmb">
             <when>

--- a/rules/jboss-eap/eap-server-migration/XmlTubameKnowHowToEAP6Rules.windup.xml
+++ b/rules/jboss-eap/eap-server-migration/XmlTubameKnowHowToEAP6Rules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlTubameKnowHowRUles">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlTubameKnowHowRUles"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
 
     <!-- Rules converted from Tubame JBossMigrationKnowhowEAP4toEAP6-En.xml -->
 

--- a/rules/jboss-eap/glassfish/XmlGlassfishRules.windup.xml
+++ b/rules/jboss-eap/glassfish/XmlGlassfishRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlGlassfishRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlGlassfishRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlGlassfishRules_2fmb">
             <when>

--- a/rules/jboss-eap/jonas/XmlJonasRules.windup.xml
+++ b/rules/jboss-eap/jonas/XmlJonasRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlJonasRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlJonasRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlJonasRules_2fmb">
             <when>

--- a/rules/jboss-eap/jonas/tests/XmlJonasRules.windup.test.xml
+++ b/rules/jboss-eap/jonas/tests/XmlJonasRules.windup.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruletest xmlns="http://windup.jboss.org/v1/xml">
+<ruletest xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final">
     <testDataPath>data</testDataPath>
     <ruleset>
         <rules>

--- a/rules/jboss-eap/jrun/XmlJrunRules.windup.xml
+++ b/rules/jboss-eap/jrun/XmlJrunRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlJrunRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlJrunRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlJrunRules_2fmb">
             <when>

--- a/rules/jboss-eap/log4j/Log4jRules.windup.xml
+++ b/rules/jboss-eap/log4j/Log4jRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="Log4jRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="Log4jRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
 	<rules>
 		<rule id="Log4jRules_2fmb">
 			<when>

--- a/rules/jboss-eap/log4j/tests/Log4jRulesTest.windup.test.xml
+++ b/rules/jboss-eap/log4j/tests/Log4jRulesTest.windup.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruletest xmlns="http://windup.jboss.org/v1/xml">
+<ruletest xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final">
 	<testDataPath>data</testDataPath>
 	<rulePath>../Log4jRules.windup.xml</rulePath>
 	<ruleset>

--- a/rules/jboss-eap/orion/XmlOrionRules.windup.xml
+++ b/rules/jboss-eap/orion/XmlOrionRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlOrionRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlOrionRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlOrionRules_2fmb">
             <when>

--- a/rules/jboss-eap/resin/XmlResinRules.windup.xml
+++ b/rules/jboss-eap/resin/XmlResinRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlResinRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlResinRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlResinRules_2fmb">
             <when>

--- a/rules/jboss-eap/weblogic/WebLogicRules.windup.xml
+++ b/rules/jboss-eap/weblogic/WebLogicRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="WebLogicRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="WebLogicRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="WebLogicRules_2fmb">
             <when>

--- a/rules/jboss-eap/weblogic/WebLogicWebServiceRules.windup.xml
+++ b/rules/jboss-eap/weblogic/WebLogicWebServiceRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="WebLogicWebServiceRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="WebLogicWebServiceRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="WebLogicWebServiceRules_2fmb">
             <when>

--- a/rules/jboss-eap/weblogic/XmlWebLogicRules.windup.xml
+++ b/rules/jboss-eap/weblogic/XmlWebLogicRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlWebLogicRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlWebLogicRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlWebLogicRules_2fmb">
             <when>

--- a/rules/jboss-eap/weblogic/tests/XmlWebLogicRulesTest.windup.test.xml
+++ b/rules/jboss-eap/weblogic/tests/XmlWebLogicRulesTest.windup.test.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruletest xmlns="http://windup.jboss.org/v1/xml">
+<ruletest xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final">
     <testDataPath>data</testDataPath>
     <rulePath>../XmlWebLogicRules.windup.xml</rulePath>
     <ruleset>

--- a/rules/jboss-eap/websphere/XmlWebSphereRules.windup.xml
+++ b/rules/jboss-eap/websphere/XmlWebSphereRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlWebsphereRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlWebsphereRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlWebsphereRules_2fmb">
             <when>

--- a/rules/jboss-portal-platform/JPPRules.windup.xml
+++ b/rules/jboss-portal-platform/JPPRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="JPPRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="JPPRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="JPPRules_2fmb">
             <when>

--- a/rules/jboss-portal-platform/XmlJPPRules.windup.xml
+++ b/rules/jboss-portal-platform/XmlJPPRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlJppRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlJppRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlJppRules_2fmb">
             <when>

--- a/rules/jbpm/5/JBossJBPMRules.windup.xml
+++ b/rules/jbpm/5/JBossJBPMRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="JBossJBPMRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="JBossJBPMRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="JBossJBPMRules_2fmb">
             <when>

--- a/rules/jdk/6/JDKUsageRules.windup.xml
+++ b/rules/jdk/6/JDKUsageRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="JDKUsageRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="JDKUsageRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="JDKUsageRules_2fmb">
             <when>

--- a/rules/soa-p/JBossEsbRules.windup.xml
+++ b/rules/soa-p/JBossEsbRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="JBossEsbRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="JBossEsbRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="JBossEsbRules_2fmb">
             <when>

--- a/rules/soa-p/XmlJBossEsbRules.windup.xml
+++ b/rules/soa-p/XmlJBossEsbRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlJbossEsbRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlJbossEsbRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlJbossEsbRules_2fmb">
             <when>

--- a/rules/uncategorized/BaseRules.windup.xml
+++ b/rules/uncategorized/BaseRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="BaseRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="BaseRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="BaseRules_2fmb">
             <when>

--- a/rules/uncategorized/Rules.windup.xml
+++ b/rules/uncategorized/Rules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="OtherBaseRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="OtherBaseRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="OtherBaseRules_2fmb">
             <when>

--- a/rules/uncategorized/XmlBaseRules.windup.xml
+++ b/rules/uncategorized/XmlBaseRules.windup.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<ruleset xmlns="http://windup.jboss.org/v1/xml" id="XmlBaseRules">
+<ruleset xmlns="http://windup.jboss.org/ns/ruleset/2.3.0.Final"  id="XmlBaseRules"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"     xsi:schemaLocation="http://windup.jboss.org/ns/ruleset/2.3.0.Final http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd"> 
     <rules>
         <rule id="XmlBaseRules_2fmb">
             <when>


### PR DESCRIPTION
Hi,

the namespaces, filenames and URLs need to be informative and "scale" in the future.

1) It needs to say windup, so people know what namespace they are dealing with.

2) Same goes for the filename - when people download it. Therefore, rule-schema-1.0.xsd is not good IMO.

3) I suggest to align the XSD version with the Windup core version, since the XSD describes what the core accepts.
    "1.0" is not fortunate, as people will confuse it with legacy Windup.
    The version string should be the same as Windup version, so we can automate things. Different formats are source of human errors.

4) It doesn't need to say "schema" - XSD is saying that.

5) It's not rule - it's a ruleset. Could be misleading.

I suggest the URL for the current XSD to be:
    http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd

And the namespace:
    Either the same,
    http://windup.jboss.org/schema/windup-ruleset-2.3.0.Final.xsd
    or,
    http://windup.jboss.org/ns/ruleset/2.3.0.Final , and that would be handled by the site (e.g., redirect to docs).

Sounds good?
Ondra 