### PR TITLE
Support running tests on the rules-reviewed folder, and increase the …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,5 +167,14 @@
                 <directory>rules</directory>
             </resource>
         </resources>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+               	<artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <argLine>-Xms512m -Xmx2048m -XX:MaxPermSize=768m -XX:ReservedCodeCacheSize=128m</argLine>
+               	</configuration>
+            </plugin>
+        </plugins>
     </build>
 </project>


### PR DESCRIPTION
…memory allocation for Surefire to prevent crashes