### PR TITLE
Removing "rule generic-catchall-00800"

### DIFF
--- a/rules-reviewed/jboss-eap/uncategorized/generic-catchall.windup.xml
+++ b/rules-reviewed/jboss-eap/uncategorized/generic-catchall.windup.xml
@@ -235,22 +235,6 @@
         </rule>
         <rule id="generic-catchall-00800">
             <when>
-                <javaclass references="javax.{subpackage}.{*}">
-                </javaclass>
-            </when>
-            <perform>
-               <classification effort="0" severity="optional" title="Java EE API"/>
-               <hint effort="1" title="{subpackage} type reference" severity="optional">
-                    <message>Java EE API {subpackage} type reference found. No specific details available.</message>
-                    <tag>catchall</tag>
-               </hint>
-            </perform>
-            <where param="subpackage">
-               <matches pattern="(persistence|management|naming|sql|ejb)" />
-            </where>
-        </rule>
-        <rule id="generic-catchall-00900">
-            <when>
                 <javaclass references="java.sql.DriverManager">
                 </javaclass>
             </when>


### PR DESCRIPTION
It is generating only false positives and its content is already fully covered by our very nicht EJB/JPA/Server resources reports.