### PR TITLE
WINDUPRULE-109: The rule for CMP entity EJBs doesn't catch ejb-jar.xml

### DIFF
--- a/rules-reviewed/eap7/eap6/tests/data/data2/ejb-jar.xml
+++ b/rules-reviewed/eap7/eap6/tests/data/data2/ejb-jar.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Testing with http://java.sun.com/xml/ns/j2ee -->
+<ejb-jar xmlns="http://java.sun.com/xml/ns/j2ee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+         version="3.1">
+    <enterprise-beans>
+        <entity>
+            <ejb-name>SimpleBMP</ejb-name>
+            <local-home>org.jboss.as.test.integration.ejb.entity.bmp.BMPLocalHome</local-home>
+            <local>org.jboss.as.test.integration.ejb.entity.bmp.BMPLocalInterface</local>
+            <ejb-class>org.jboss.as.test.integration.ejb.entity.bmp.SimpleBMPBean</ejb-class>
+            <persistence-type>Container</persistence-type>
+            <prim-key-class>java.lang.Integer</prim-key-class>
+            <reentrant>true</reentrant>
+        </entity>
+    </enterprise-beans>
+</ejb-jar>

--- a/rules-reviewed/eap7/eap6/tests/eap6-xml.windup.test.xml
+++ b/rules-reviewed/eap7/eap6/tests/eap6-xml.windup.test.xml
@@ -6,11 +6,13 @@
             <rule id="eap6-xml-01000-test">
                 <when>
                     <not>
-                        <hint-exists message="CMP entity beans are no longer supported in JBoss EAP 7. User is requested to use JPA"/>
+                      <iterable-filter size="2">
+                        <hint-exists message="Configuration provided in this ejb-jar.xml should be configured using JPA persistence.xml or using JPA annotations."/>
+                      </iterable-filter>
                     </not>
                 </when>
                 <perform>
-                    <fail message="CMP Entity EJB hint not found!"/>
+                    <fail message="There should be 2 hints for CMP Entity definitions in ejb-jar.xml"/>
                 </perform>
             </rule>
             <rule id="eap6-xml-02000-test">


### PR DESCRIPTION
Needs to be fixed in windup