### PR TITLE
URL Correction for JMS Configuration documentation

### DIFF
--- a/rules-reviewed/eap6/weblogic/weblogic-xml-descriptors.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-xml-descriptors.windup.xml
@@ -223,7 +223,7 @@
             <perform>
                 <classification title="WebLogic JMS Descriptor" severity="mandatory" effort="3">
                     <link
-                        href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#sect-Configuration"
+                        href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#sect-Configuration1"
                         title="EAP 6 JMS Server configuration" />
                     <tag>jms</tag>
                     <tag>configuration</tag>


### PR DESCRIPTION
…the following:

https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#sect-Configuration

This URL leads to configuration information for Hibernate. i.e. it is the wrong URL. The correct URL is the following:

https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#sect-Configuration1

This URL goes to the JMS Configuration information section of the document, which is what is required. The "1" at the end of the URL is the only difference the two URLs