### PR TITLE
WINDUPRULE-147 removed classification for generic-catchall-00001 aka …

### DIFF
--- a/rules-reviewed/eap6/uncategorized/generic-catchall.windup.xml
+++ b/rules-reviewed/eap6/uncategorized/generic-catchall.windup.xml
@@ -59,9 +59,6 @@
                         </not>
                     </when>
                     <perform>
-                        <classification title="backport-util-concurrent" severity="mandatory">
-                            <tag>catchall</tag>
-                        </classification>
                         <hint effort="0" severity="mandatory" title="backport-util-concurrent type reference">
                             <message>
                                 This type is the backport of java.util.concurrent API, introduced in Java 5.0 and further refined in Java 6.0, to older Java platforms. 

--- a/rules-reviewed/eap6/uncategorized/tests/generic-catchall.windup.test.xml
+++ b/rules-reviewed/eap6/uncategorized/tests/generic-catchall.windup.test.xml
@@ -17,7 +17,7 @@
          <rule id="generic-catchall-00001-test">
             <when>
                <not>
-                  <classification-exists classification="backport-util-concurrent" />
+                  <hint-exists message=".*This type is the backport of java.util.concurrent API.*" />
                </not>
             </when>
             <perform>


### PR DESCRIPTION
…backport-util-concurrent library usage

https://issues.jboss.org/browse/WINDUPRULE-147