### PR TITLE
WINDUPRULE-169 - EAP 7 api jars inclusion into package jar

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,7 +253,7 @@
                      <include>**/*.windup.xml</include>
                      <include>**/*.technology.metadata.xml</include>
                      <include>eap6/api-jars/*.jar</include>
-                     <!--<include>eap7/api-jars/*.jar</include>-->
+                     <include>eap7/api-jars/*.jar</include>
                      <include>**/*.xsl</include>
                   </includes>
                </configuration>


### PR DESCRIPTION
@Ladicek found that the Enum constant discovery fails so I realized that the api-jars for EAP7 are not there. 