### PR TITLE
fix jspf->jpsf typo in windows path rule

### DIFF
--- a/rules-reviewed/os/windows/os-specific.windup.xml
+++ b/rules-reviewed/os/windows/os-specific.windup.xml
@@ -23,12 +23,12 @@
             </when>
             <perform>
                 <hint title="Windows file system path" effort="1" severity="mandatory">
-                    <message>This file system path is Windows platform dependent. It is needed to adapt to a Linux plaftorm dependent.</message>
+                    <message>This file system path is Windows platform dependent. It needs to be replaced with a Linux-style path.</message>
                     <tag>os-windows</tag>
                 </hint>
             </perform>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jpsf|tag|xml|txt|js)" />
+                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|js)" />
             </where>
             <where param="pattern">
                 <matches pattern="(([A-Z|a-z]:[\\][^/]?)|(\\\\[^\\]+\\))" />


### PR DESCRIPTION
Also rewording help text, if new wording looks OK