### PR TITLE
revert dynamic instantiation rule to optional with 0 effort

### DIFF
--- a/rules-reviewed/eap6/uncategorized/environment-dependent.windup.xml
+++ b/rules-reviewed/eap6/uncategorized/environment-dependent.windup.xml
@@ -23,7 +23,7 @@
                 </javaclass>
             </when>
             <perform>
-                 <hint title="Dynamic class instantiation" effort="1" severity="mandatory">
+                 <hint title="Dynamic class instantiation" effort="0" severity="optional">
                      <message>
                        <![CDATA[
                        The class is dynamically loaded within application. During the migration, multiple classes that are provided on classpath by a different server may not be present anymore.


### PR DESCRIPTION
Per discussion with Jess, Robb, Marc Z; no objections. Won't fix the entire issue with this rule, but will at least stop it from dominating the story points wherever it shows up and making the overall estimates useless.