### PR TITLE
Remove effort from catchall rules.

### DIFF
--- a/rules-reviewed/eap6/weblogic/weblogic-catchall.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-catchall.windup.xml
@@ -201,7 +201,7 @@
                         </not>
                     </when>
                     <perform>
-                        <hint title="Oracle proprietary JDBC type reference" effort="1" severity="optional">
+                        <hint title="Oracle proprietary JDBC type reference" effort="0" severity="optional">
                             <message>
                               <![CDATA[
                               This is an Oracle proprietary JDBC type (`oracle.sql.{remainder}`).
@@ -257,7 +257,7 @@
                         </not>
                     </when>
                     <perform>
-                        <hint title="WebLogic proprietary type reference" effort="1" severity="potential">
+                        <hint title="WebLogic proprietary type reference" effort="0" severity="potential">
                             <message>
                               <![CDATA[
                               This is an Oracle WebLogic proprietary type (`weblogic.{remainder}`) and needs to be migrated to a compatible API. There is currently no detailed

--- a/rules-reviewed/eap6/websphere/websphere-catchall.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-catchall.windup.xml
@@ -29,7 +29,7 @@
                         </not>
                     </when>
                     <perform>
-                        <hint title="IBM proprietary type reference" effort="1" severity="potential">
+                        <hint title="IBM proprietary type reference" effort="0" severity="potential">
                             <message>
                                 This is an IBM proprietary type ({package}.{type}) and needs to be migrated to a compatible API. There is currently no detailed
                                 information about this type.
@@ -58,7 +58,7 @@
                         </not>
                     </when>
                     <perform>
-                        <hint title="IBM ILog proprietary type reference" effort="1" severity="potential">
+                        <hint title="IBM ILog proprietary type reference" effort="0" severity="potential">
                             <message>
                                 This is an IBM ILog proprietary type (ilog.{subpackage}.{type}) and needs to be migrated to a compatible API. There is currently no detailed
                                 information about this type.


### PR DESCRIPTION
When a catchall rule triggers in an application, it tends to trigger many times. This makes catchall rules with effort tend to dominate story point counts in a way that makes them less useful. It also causes performance problems on large applications by attaching effort to many thousands of issues.

Command used to check for instances of catchalls with effort:
d^@^:windup-rulesets$ find rules-reviewed -name "*.windup.xml" | grep catchall | xargs grep effort | grep -v "effort=\"0\""
rules-reviewed/eap6/websphere/websphere-catchall.windup.xml:                        <hint title="IBM proprietary type reference" effort="1" severity="potential">
rules-reviewed/eap6/websphere/websphere-catchall.windup.xml:                        <hint title="IBM ILog proprietary type reference" effort="1" severity="potential">
rules-reviewed/eap6/weblogic/weblogic-catchall.windup.xml:                        <hint title="Oracle proprietary JDBC type reference" effort="1" severity="optional">
rules-reviewed/eap6/weblogic/weblogic-catchall.windup.xml:                        <hint title="WebLogic proprietary type reference" effort="1" severity="potential">