### PR TITLE
Don't trigger eap6's websphere-xml ruleset for EAP 7.

### DIFF
--- a/rules-reviewed/eap6/websphere/websphere-xml.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-xml.windup.xml
@@ -9,7 +9,7 @@
             <addon id="org.jboss.windup.rules,windup-rules-xml,2.7.0.Final"/>
         </dependencies>
         <sourceTechnology id="websphere"/>
-        <targetTechnology id="eap" versionRange="[6,8)"/>
+        <targetTechnology id="eap" versionRange="[6,7)"/>
         <tag>reviewed-2017-01-06</tag>
     </metadata>
     <rules>


### PR DESCRIPTION
There's a separate eap7-websphere-xml for EAP 7. Noticed this ruleset caused duplicate hits in a test app.