### PR TITLE
T978 Remove the tag targetTechnology "openshift" from the rules that have it

### DIFF
--- a/rules-reviewed/openshift/java-rmi.windup.xml
+++ b/rules-reviewed/openshift/java-rmi.windup.xml
@@ -11,7 +11,6 @@
         </dependencies>
         <sourceTechnology id="java" />
         <sourceTechnology id="rmi" />
-        <targetTechnology id="openshift" />
         <targetTechnology id="cloud-readiness" />
     </metadata>
     <rules>

--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -10,7 +10,6 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="cloud-readiness" />
-        <targetTechnology id="openshift" />
     </metadata>
      <!--
        This rules could be merged together but they need to be separated due to issue WINDUP-1324 [https://issues.jboss.org/projects/WINDUP/issues/WINDUP-1324]

--- a/rules-reviewed/openshift/logging.windup.xml
+++ b/rules-reviewed/openshift/logging.windup.xml
@@ -13,7 +13,6 @@
         </dependencies>
         <sourceTechnology id="java"/>
         <sourceTechnology id="java-ee"/>
-        <targetTechnology id="openshift"/>
         <targetTechnology id="cloud-readiness"/>
         <tag>logging</tag>
     </metadata>

--- a/rules-reviewed/openshift/mail.windup.xml
+++ b/rules-reviewed/openshift/mail.windup.xml
@@ -14,7 +14,6 @@
         <sourceTechnology id="java"/>
         <sourceTechnology id="java-ee"/>
         <targetTechnology id="cloud-readiness"/>
-        <targetTechnology id="openshift"/>
         <tag>mail</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/openshift/session.windup.xml
+++ b/rules-reviewed/openshift/session.windup.xml
@@ -14,7 +14,6 @@
         <sourceTechnology id="java"/>
         <sourceTechnology id="java-ee"/>
         <targetTechnology id="cloud-readiness"/>
-        <targetTechnology id="openshift"/>
         <tag>clustering</tag>
     </metadata>
     <rules>


### PR DESCRIPTION
`cloud-readiness` it the target id used for cloud-related rules instead of `openshift` ([see release notes](https://access.redhat.com/articles/2991361))