### PR TITLE
WINDUPRULE-224 Removing 'js' extension from local storage rule

### DIFF
--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -143,7 +143,7 @@
                 <matches pattern="(([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?" />
             </where>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|js)" />
+                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt)" />
             </where>
         </rule>
         <rule id="local-storage-00004">


### PR DESCRIPTION
To avoid further false negatives, rule `local-storage-00003` does not search for path in `js` files anymore.