### PR TITLE
WINDUPRULE-232 Rule `jboss-eap5and6to7-xml-33000` hint title wording

### DIFF
--- a/rules-reviewed/eap7/eap5and6/jboss-eap5and6to7-xml.windup.xml
+++ b/rules-reviewed/eap7/eap5and6/jboss-eap5and6to7-xml.windup.xml
@@ -256,7 +256,7 @@
             </when>
             <perform>
                 <iteration>
-                    <hint title="JAX-RPC specific configuration." effort="3" category-id="mandatory">
+                    <hint title="JAX-RPC specific configuration" effort="3" category-id="mandatory">
                     <message>JAX-RPC support was removed in JBoss EAP 7. All the RPC calls will need to be migrated to JAX-WS.</message>
                     <link href="https://access.redhat.com/documentation/en/red-hat-jboss-enterprise-application-platform/version-7.0/migration-guide/#migrate_jax_rpc_support_changes" title="JAX-RPC support changes" />
                     <tag>rpc</tag>


### PR DESCRIPTION
Remove the “.” at the end of the title of the “JAX-RPC specific configuration.” title.
