### PR TITLE
WINDUPRULE-233 Lucene rules: improving hint's titles

### DIFF
--- a/rules-reviewed/eap7/eap6/hsearch.windup.xml
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.xml
@@ -895,7 +895,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.queryParser.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.queryParser'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.queryparser.classic'" effort="1" category-id="optional">
                     <message>Lucene's core `org.apache.lucene.queryParser.{type}` have been consolidated into lucene/queryparser, that results in changing package name so it is now named as `org.apache.lucene.queryparser.classic.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
                     <link href="http://hibernate.org/search/documentation/migrate/5.0/#within-apache-lucene" title="Renamed classes within Apache Lucene" />
@@ -961,7 +961,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.analysis'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.analysis.core'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.{type}` to `org.apache.lucene.analysis.core.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -983,7 +983,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.PorterStemFilter" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package for class PorterStemFilter" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Class 'PorterStemFilter' repackaged to 'org.apache.lucene.analysis.en'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.PorterStemFilter` to `org.apache.lucene.analysis.en.PorterStemFilter`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1006,7 +1006,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.analysis'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.analysis.miscellaneous'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.{type}` to `org.apache.lucene.analysis.miscellaneous.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1028,7 +1028,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.TeeSinkTokenFilter" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package for class TeeSinkTokenFilter" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Class 'TeeSinkTokenFilter' repackaged to 'org.apache.lucene.analysis.sinks'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.TeeSinkTokenFilter` to `org.apache.lucene.analysis.sinks.TeeSinkTokenFilter`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1050,7 +1050,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.analysis'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.analysis.charfilter'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.{type}` to `org.apache.lucene.analysis.charfilter.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1076,7 +1076,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.analysis'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.analysis.util'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.analysis.{type}` to `org.apache.lucene.analysis.util.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1098,7 +1098,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.analysis.ReusableAnalyzerBase" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package for class ReusableAnalyzerBase" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Class 'ReusableAnalyzerBase' renamed to 'org.apache.lucene.analysis.Analyzer'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring class name have changed for `org.apache.lucene.analysis.ReusableAnalyzerBase` to `org.apache.lucene.analysis.Analyzer`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1117,7 +1117,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.util.CharacterUtils" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package for class CharacterUtils" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Class 'CharacterUtils' repackaged to 'org.apache.lucene.analysis.util'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.util.CharacterUtils` to `org.apache.lucene.analysis.util.CharacterUtils`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1139,7 +1139,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.search.function.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.search.function'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.queries'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.search.function.{type}` to `org.apache.lucene.queries.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1161,7 +1161,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.search.function.NumericIndexDocValueSource" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package for class NumericIndexDocValueSource" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Class 'NumericIndexDocValueSource' repackaged to 'org.apache.lucene.queries.function.valuesource'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.search.function.NumericIndexDocValueSource` to `org.apache.lucene.queries.function.valuesource.NumericIndexDocValueSource`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1184,7 +1184,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.search.function.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.search.function'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.queries.function'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.search.function.{type}` to `org.apache.lucene.queries.function.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1212,7 +1212,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.lucene.search.function.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Renamed package 'org.apache.lucene.search.function'" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Classes repackaged to 'org.apache.lucene.queries.function.valuesources'" effort="1" category-id="optional">
                     <message>Lucene's core and contrib analyzers, along with Solr's analyzers, were consolidated into lucene/analysis module.
                      During the refactoring package name have changed for `org.apache.lucene.search.function.{type}` to `org.apache.lucene.queries.function.valuesources.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
@@ -1236,7 +1236,7 @@ fulltextQuery.setSort(new Sort(new SortField("title", SortField.Type.STRING)))
                 <javaclass references="org.apache.solr.analysis.{type}" />
             </when>
             <perform>
-                <hint title="Lucene 4.x - Moved Apache Solr 'org.apache.solr.analysis' classes" effort="1" category-id="optional">
+                <hint title="Lucene 4.x - Solr classes repackaged to 'org.apache.lucene.analysis.util'" effort="1" category-id="optional">
                     <message>Solr utilities class `org.apache.solr.analysis.{type}` was moved into Apache Lucene so you can use `org.apache.lucene.analysis.util.{type}`.</message>
                     <link href="http://lucene.apache.org/core/4_10_2/MIGRATE.html" title="Apache Lucene Migration Guide" />
                     <link href="http://hibernate.org/search/documentation/migrate/5.0/#within-apache-lucene" title="Renamed classes within Apache Lucene" />


### PR DESCRIPTION
Added the name of the package to migrate to in hint's title to avoid giving the perception of duplicates rules and help the user to better address and understand the needed changes.