### PR TITLE
WINDUPRULE-278: Fixing cloud readiness rules

### DIFF
--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -30,11 +30,11 @@
                     </javaclass>
                     <javaclass references="java.nio.file.Paths.get({*})">
                         <location>METHOD_CALL</location>
-                    </javaclass>
+                    </javaclass> 
                 </or>
             </when>
             <perform>
-                <hint title="Local file system access" effort="1" category-id="cloud-mandatory">
+                <hint title="File system - Java IO" effort="1" category-id="cloud-mandatory">
                     <message>
                     Accessing a file on a local storage in a cloud environment is not safe because, inside a running container, an application can never assume that anything stored on disk will be permanently available because a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location) will usually wipe out all local (e.g., memory and filesystem) state.
 
@@ -73,7 +73,7 @@
                 </javaclass>
             </when>
             <perform>
-                <hint title="URL/URI with 'file' scheme" effort="1" category-id="cloud-mandatory">
+                <hint title="File system - java.net.URL/URI" effort="1" category-id="cloud-mandatory">
                     <message>
                     Accessing a file on a local storage in a cloud environment is not safe because, inside a running container, an application can never assume that anything stored on disk will be permanently available because a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location) will usually wipe out all local (e.g., memory and filesystem) state.
 
@@ -107,10 +107,10 @@
         </rule>
         <rule id="local-storage-00003">
             <when>
-                <filecontent pattern="{path1}" filename="{*}.{extensions}"/>
+                <filecontent pattern="{path1}" filename="{*}{extensions}"/>
             </when>
             <perform>
-                <hint title="Local file system path" effort="1" category-id="cloud-mandatory">
+                <hint title="File system - File path URL" effort="1" category-id="cloud-mandatory">
                     <message>
                     Accessing a file on a local storage in a cloud environment is not safe because, inside a running container, an application can never assume that anything stored on disk will be permanently available because a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location) will usually wipe out all local (e.g., memory and filesystem) state.
 
@@ -140,10 +140,11 @@
             </perform>
             <where param="path1">
                 <!-- absolute paths on windows -->
+                <!-- UPDATE TO REMOVE PATTERNS STARTING WITH java: AND classpath: -->
                 <matches pattern="(([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?" />
             </where>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt)" />
+                <matches pattern="(\\.java|\\.properties|\\.jsp|\\.jspf|\\.tag|[^pom]\\.xml|\\.txt)" />
             </where>
         </rule>
         <rule id="local-storage-00004">
@@ -151,7 +152,7 @@
                 <filecontent pattern="{path2}" filename="{*}.{extensions}" />
             </when>
             <perform>
-                <hint title="URL with local file system path" effort="1" category-id="cloud-mandatory">
+                <hint title="File system - 'file://' scheme" effort="1" category-id="cloud-mandatory">
                     <message>
                     Accessing a file on a local storage in a cloud environment is not safe because, inside a running container, an application can never assume that anything stored on disk will be permanently available because a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location) will usually wipe out all local (e.g., memory and filesystem) state.
 
@@ -184,27 +185,29 @@
                 <matches pattern="file://" />
             </where>
             <where param="extensions">
-                <matches pattern="(java|properties|jsp|jspf|tag|xml|txt|js)" />
+                <matches pattern="(\\.java|\\.properties|\\.jsp|\\.jspf|\\.tag|[^pom]\\.xml|\\.txt)" />
             </where>
         </rule>
         <rule id="local-storage-00005">
             <when>
-              <or>
-                  <javaclass references="java.nio.channels.AsynchronousFileChannel{*}" />
-                  <javaclass references="java.nio.channels.FileChannel{*}" />
-                  <javaclass references="java.nio.channels.FileLock{*}" />
-                  <javaclass references="java.nio.file.DirectoryStream{*}" />
-                  <javaclass references="java.nio.file.Files{*}" />
-                  <javaclass references="java.nio.file.FileStore{*}" />
-                  <javaclass references="java.nio.file.FileSystem{*}" />
-                  <javaclass references="java.nio.file.FileSystems{*}" />
-                  <javaclass references="java.nio.file.Path{*}" />
-                  <javaclass references="java.nio.file.Paths{*}" />
-              </or>
+                <or>
+                    <javaclass references="java.nio.channels.AsynchronousFileChannel{*}">
+                        <location>IMPORT</location>
+                    </javaclass>
+                    <javaclass references="java.nio.channels.FileChannel{*}">
+                        <location>IMPORT</location>
+                    </javaclass>
+                    <javaclass references="java.nio.channels.FileLock{*}">
+                        <location>IMPORT</location>
+                    </javaclass>
+                    <javaclass references="java.nio.file.{*}">
+                        <location>IMPORT</location>
+                    </javaclass>
+                </or>
             </when>
             <perform>
               <iteration>
-                <hint title="Java APIs for local file system (java.nio classes)" effort="3" category-id="cloud-mandatory">
+                <hint title="File system - Java NIO" effort="1" category-id="cloud-mandatory">
                     <message>
                     Accessing a file on a local storage in a cloud environment is not safe because, inside a running container, an application can never assume that anything stored on disk will be permanently available because a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location) will usually wipe out all local (e.g., memory and filesystem) state.
 

--- a/rules-reviewed/openshift/logging.windup.xml
+++ b/rules-reviewed/openshift/logging.windup.xml
@@ -21,30 +21,49 @@
             <when>
               <or>
                 <filecontent filename="log4j.{extension}" pattern="{appenderpattern}"/>
-                <javaclass references="org.apache.{*}log4j.{*}FileAppender{*}" />
-                <javaclass references="java.util.logging.FileHandler{*}"/>
-                <javaclass references="ch.qos.logback.core.FileAppender"/>
-                <javaclass references="org.pmw.tinylog.writers.FileWriter"/>
-                <javaclass references="org.slf4j.{*}"/>
-                <javaclass references="org.apache.commons.logging.{*}"/>
+                <javaclass references="org.apache.{*}log4j.{*}FileAppender{*}">
+                    <location>IMPORT</location>
+                </javaclass>
+                <javaclass references="java.util.logging.FileHandler{*}">
+                    <location>IMPORT</location>
+                </javaclass>
+                <javaclass references="ch.qos.logback.core.FileAppender">
+                    <location>IMPORT</location>
+                </javaclass>
+                <javaclass references="org.pmw.tinylog.writers.FileWriter">
+                    <location>IMPORT</location>
+                </javaclass>
+                <javaclass references="org.slf4j.{*}">
+                    <location>IMPORT</location>
+                </javaclass>
+                <javaclass references="org.apache.commons.logging.{*}">
+                    <location>IMPORT</location>
+                </javaclass>
               </or>
             </when>
             <perform>
                 <iteration>
-                    <hint title="Logging to file system" effort="3" category-id="cloud-mandatory">
-                        <message>
-                        Logging to individual files should be avoided in a cloud environment, as locally written log files may be lost on instance termination or restart.  
-                        
-                        Review the file-based logging and considered the following options:
-                        
-                        * usage of a centralized log management system
-                        * log to standard output (console) and let the cloud platform handle the output
-                        * usage of shared storage for log files
-                        </message>
-                        <link href="https://12factor.net/logs" title="Twelve-factor app - Logs"/>
-                        <link href="https://access.redhat.com/documentation/en/openshift-container-platform/3.4/paged/installation-and-configuration/chapter-28-aggregating-container-logs" title="Aggregating container logs"/>
-                        <tag>logging</tag>
-                    </hint>
+                    <when>
+                        <not>
+                            <has-hint />
+                        </not>
+                    </when>
+                    <perform>
+                        <hint title="Logging to file system" effort="1" category-id="cloud-mandatory">
+                            <message>
+                            Logging to individual files should be avoided in a cloud environment, as locally written log files may be lost on instance termination or restart.
+
+                            Review the file-based logging and considered the following options:
+
+                            * usage of a centralized log management system
+                            * log to standard output (console) and let the cloud platform handle the output
+                            * usage of shared storage for log files
+                            </message>
+                            <link href="https://12factor.net/logs" title="Twelve-factor app - Logs"/>
+                            <link href="https://access.redhat.com/documentation/en/openshift-container-platform/3.4/paged/installation-and-configuration/chapter-28-aggregating-container-logs" title="Aggregating container logs"/>
+                            <tag>logging</tag>
+                        </hint>
+                    </perform>
                 </iteration>
             </perform>
             <where param="appenderpattern">
@@ -62,10 +81,10 @@
                 <iteration>
                     <hint title="Logging to Socket Handler" effort="3" category-id="cloud-mandatory">
                         <message>
-                        Socket communication is not suitable in a cloud environment which does not provide fixed communication target hosts.  
+                        Socket communication is not suitable in a cloud environment which does not provide fixed communication target hosts.
 
                         Review the socket-based logging and considered the following options:
-                        
+
                         * usage of a centralized log management system
                         * log to standard output (console) and let the cloud platform handle the output
                         * usage of shared storage for log files

--- a/rules-reviewed/openshift/session.windup.xml
+++ b/rules-reviewed/openshift/session.windup.xml
@@ -24,33 +24,33 @@
               </xmlfile>
             </when>
             <perform>
-                <hint title="HTTP Session replication" effort="3" category-id="cloud-mandatory">
+                <hint title="HTTP session replication (distributable web.xml)" effort="3" category-id="cloud-mandatory">
                     <message>
                     <![CDATA[
-                       Session replication ensures that client sessions are not disrupted by failovers of nodes in a cluster.  
-                       Each node in the cluster shares information about ongoing sessions and can take over sessions if a node disappears.  
-                       The `<distributable/>` tag inside the `<web-app>` tag of application’s `web.xml` descriptor file enables the application's sessions clustering [1].  
-                       
-                       In a cloud environment it has to be considered that the data in the memory of a running container can be wiped out by a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location)[2].  
-                       
+                       Session replication ensures that client sessions are not disrupted by failovers of nodes in a cluster.
+                       Each node in the cluster shares information about ongoing sessions and can take over sessions if a node disappears.
+                       The `<distributable/>` tag inside the `<web-app>` tag of application’s `web.xml` descriptor file enables the application's sessions clustering [1].
+
+                       In a cloud environment it has to be considered that the data in the memory of a running container can be wiped out by a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location)[2].
+
                        Different approaches can be followed:
-                       
+
                        * review session replication's usage and make sure it is configured properly (effort 3) [3]
                        * rearchitect the application and consider storing sessions in a cache backing service (effort 7) [6][7][4][5]
                        * disable HTTP session clustering and accept its implications
-                       
+
                        The second approach (using a cache backing service) has some benefits:
-                       
-                       * Increased application scalability and elasticity. By offloading the session data off to a remote Data Grid, the application tier itself can be more scalable and elastic. 
-                       * Session Persistence. By offloading session data to a remote data grid, the application itself will be able to survive EAP node failures since the a JVM failure will not cause the session data to be lost. 
+
+                       * Increased application scalability and elasticity. By offloading the session data off to a remote Data Grid, the application tier itself can be more scalable and elastic.
+                       * Session Persistence. By offloading session data to a remote data grid, the application itself will be able to survive EAP node failures since the a JVM failure will not cause the session data to be lost.
                        * Session Data Sharing. If you have a requirement for multiple applications to be able to share session data, this solution might be able to solve that use case as well.
-                       
+
                        References:
-                       
+
                        1. [JBoss EAP - Clustering in Web Applications](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/development_guide/clustering_in_web_applications)
                        2. [Twelve-factor app - Processes](https://12factor.net/processes)
                        3. [OpenShift - JBoss EAP Clustering](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html-single/red_hat_jboss_enterprise_application_platform_for_openshift/#clustering)
-                       4. [Twelve-factor app - Backing services](https://12factor.net/backing-services) 
+                       4. [Twelve-factor app - Backing services](https://12factor.net/backing-services)
                        5. [Red Hat JBoss Data Grid for OpenShift](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_jboss_data_grid_for_openshift/)
                        6. [JBoss EAP - Externalize HTTP Sessions to JBoss Data Grid](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#externalize-http-sessions-to-jdg)
                        7. [Developer blog post - Externalize HTTP Session Data to the JBoss Data Grid](https://developers.redhat.com/blog/2015/11/23/externalize-http-session-data-to-jboss-data-grid/)
@@ -72,26 +72,26 @@
                 <hint title="HTTP Session data storage" effort="3" category-id="cloud-optional">
                     <message>
                     <![CDATA[
-                    The servlet container uses HttpSession to create a session between an HTTP client and an HTTP server.  
-                    The session persists for a specified time period, across more than one connection or page request from the user.  
-                    `HttpSession.setAttribute` method allows user information to persist across multiple user connections  
-                    Warning: As of Java Servlet Version 2.2, the `javax.http.HTTPSession.putValue(java.lang.String name,java.lang.Object value)` method is deprecated and replaced by `javax.http.HttpSession.setAttribute(java.lang.String, java.lang.Object)`  
-                    
-                    In a cloud environment it has to be considered that the data in the memory of a running container can be wiped out by a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location)[1].  
-                    Consider storing HTTPSession data to a cache backing service[2][3][4][5]  
+                    The servlet container uses HttpSession to create a session between an HTTP client and an HTTP server.
+                    The session persists for a specified time period, across more than one connection or page request from the user.
+                    `HttpSession.setAttribute` method allows user information to persist across multiple user connections
+                    Warning: As of Java Servlet Version 2.2, the `javax.http.HTTPSession.putValue(java.lang.String name,java.lang.Object value)` method is deprecated and replaced by `javax.http.HttpSession.setAttribute(java.lang.String, java.lang.Object)`
+
+                    In a cloud environment it has to be considered that the data in the memory of a running container can be wiped out by a restart (triggered by code deploy, config change, or the execution environment relocating the process to a different physical location)[1].
+                    Consider storing HTTPSession data to a cache backing service[2][3][4][5]
                     This approach has some benefits:
-                    
-                    * Increased application scalability and elasticity. By offloading the session data off to a remote Data Grid, the application tier itself can be more scalable and elastic. 
-                    * Session Persistence. By offloading session data to a remote data grid, the application itself will be able to survive EAP node failures since the a JVM failure will not cause the session data to be lost. 
+
+                    * Increased application scalability and elasticity. By offloading the session data off to a remote Data Grid, the application tier itself can be more scalable and elastic.
+                    * Session Persistence. By offloading session data to a remote data grid, the application itself will be able to survive EAP node failures since the a JVM failure will not cause the session data to be lost.
                     * Session Data Sharing. If you have a requirement for multiple applications to be able to share session data, this solution might be able to solve that use case as well.
-                    
+
                     References:
-                    
+
                     1. [Twelve-factor app - Processes](https://12factor.net/processes)
                     2. [JBoss EAP - Externalize HTTP Sessions to JBoss Data Grid](https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html/configuration_guide/configuring_high_availability#externalize-http-sessions-to-jdg)
-                    3. [Developer blog post - Externalize HTTP Session Data to the JBoss Data Grid](https://developers.redhat.com/blog/2015/11/23/externalize-http-session-data-to-jboss-data-grid/) 
-                    4. [Twelve-factor app - Backing services](https://12factor.net/backing-services) 
-                    5. [Red Hat JBoss Data Grid for OpenShift](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_jboss_data_grid_for_openshift/) 
+                    3. [Developer blog post - Externalize HTTP Session Data to the JBoss Data Grid](https://developers.redhat.com/blog/2015/11/23/externalize-http-session-data-to-jboss-data-grid/)
+                    4. [Twelve-factor app - Backing services](https://12factor.net/backing-services)
+                    5. [Red Hat JBoss Data Grid for OpenShift](https://access.redhat.com/documentation/en-us/red_hat_jboss_middleware_for_openshift/3/html/red_hat_jboss_data_grid_for_openshift/)
                     ]]>
                     </message>
                     <tag>clustering</tag>

--- a/rules-reviewed/openshift/tests/local-storage.windup.test.xml
+++ b/rules-reviewed/openshift/tests/local-storage.windup.test.xml
@@ -8,8 +8,8 @@
             <rule id="local-storage-test-00001">
                 <when>
                     <not>
-                        <iterable-filter size="57">
-                            <hint-exists message="Accessing a file on a local storage in a cloud environment is not safe because*" />
+                        <iterable-filter size="29">
+                            <hint-exists message=".*Accessing a file on a local storage in a cloud environment is not safe because,.*" />
                         </iterable-filter>
                     </not>
                 </when>

--- a/rules-reviewed/openshift/tests/logging.windup.test.xml
+++ b/rules-reviewed/openshift/tests/logging.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="logging-test-00000">
                 <when>
                     <not>
-                        <iterable-filter size="25">
+                        <iterable-filter size="14">
   	                      <hint-exists message="Logging to individual files should be avoided in a cloud environment*" />
                         </iterable-filter>
                     </not>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUPRULE-278

I haven't included the following 2 changes for javaclass references:

- https://github.com/Maarc/windup-rulesets/commit/34e22f864ec30eeed35c67606da77f17005cd9a9#diff-68179b4994e8c1c844d59163c749a893L193
- https://github.com/Maarc/windup-rulesets/commit/34e22f864ec30eeed35c67606da77f17005cd9a9#diff-096466b775ea2df36893bdce01c54584L23

Does he have some reasoning for them?