### PR TITLE
WINDUP-1622: ignoring javax/com mail API classes in scanning

### DIFF
--- a/rules-reviewed/openshift/mail.windup.xml
+++ b/rules-reviewed/openshift/mail.windup.xml
@@ -40,5 +40,9 @@
               </hint>
             </perform>
         </rule>
+
+        <!-- DO NOT include into scanning Mail API classes -->
+        <javaclass-ignore reference-prefix="com.sun.mail"/>
+        <javaclass-ignore reference-prefix="javax.mail"/>
     </rules>
 </ruleset>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-1622