### PR TITLE
WINDUPRULE-273: removing SLF4J and Apache Commons Logging

### DIFF
--- a/rules-reviewed/openshift/logging.windup.xml
+++ b/rules-reviewed/openshift/logging.windup.xml
@@ -33,12 +33,6 @@
                 <javaclass references="org.pmw.tinylog.writers.FileWriter">
                     <location>IMPORT</location>
                 </javaclass>
-                <javaclass references="org.slf4j.{*}">
-                    <location>IMPORT</location>
-                </javaclass>
-                <javaclass references="org.apache.commons.logging.{*}">
-                    <location>IMPORT</location>
-                </javaclass>
               </or>
             </when>
             <perform>

--- a/rules-reviewed/openshift/tests/data/Logging.java
+++ b/rules-reviewed/openshift/tests/data/Logging.java
@@ -5,8 +5,6 @@ import java.util.logging.FileHandler;
 import java.util.logging.SocketHandler;
 import ch.qos.logback.core.FileAppender;
 import org.pmw.tinylog.writers.FileWriter;
-import org.slf4j.Logger;
-import org.apache.commons.logging.Log;
 
 public class Logging {
 	

--- a/rules-reviewed/openshift/tests/logging.windup.test.xml
+++ b/rules-reviewed/openshift/tests/logging.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="logging-test-00000">
                 <when>
                     <not>
-                        <iterable-filter size="14">
+                        <iterable-filter size="12">
   	                      <hint-exists message="Logging to individual files should be avoided in a cloud environment*" />
                         </iterable-filter>
                     </not>


### PR DESCRIPTION
Changes after feedbacks from the field that conditions for SLF4J and Apache Commons Logging generate too much noise in the report.