### PR TITLE
WINDUPRULE-274: enhanced Windows path identification and bug fix

### DIFF
--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -141,10 +141,10 @@
             <where param="path1">
                 <!-- absolute paths on windows -->
                 <!-- UPDATE TO REMOVE PATTERNS STARTING WITH java: AND classpath: -->
-                <matches pattern="(([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?" />
+                <matches pattern="(([:=(])([ ])*([&quot;'])?([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?"/>
             </where>
             <where param="extensions">
-                <matches pattern="(\\.java|\\.properties|\\.jsp|\\.jspf|\\.tag|[^pom]\\.xml|\\.txt)" />
+                <matches pattern="(\.java|\.properties|\.jsp|\.jspf|\.tag|[^pom]\.xml|\.txt)" />
             </where>
         </rule>
         <rule id="local-storage-00004">

--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -141,7 +141,7 @@
             <where param="path1">
                 <!-- absolute paths on windows -->
                 <!-- UPDATE TO REMOVE PATTERNS STARTING WITH java: AND classpath: -->
-                <matches pattern="(([:=(])([ ])*([&quot;'])?([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?"/>
+                <matches pattern="(([:=(,\{])([ ])*([&quot;'])?([a-zA-Z]):)(?&lt;![\&lt;\\\/\d\w])([\\\/]\w+)+(\.\w+)?"/>
             </where>
             <where param="extensions">
                 <matches pattern="(\.java|\.properties|\.jsp|\.jspf|\.tag|[^pom]\.xml|\.txt)" />

--- a/rules-reviewed/openshift/tests/data/LocalFileUsage.java
+++ b/rules-reviewed/openshift/tests/data/LocalFileUsage.java
@@ -64,6 +64,7 @@ public class LocalFileUsage {
 	    // the next 2 lines test that rule 'local-storage-00002' is only fired from the 2nd line
 	    URL url1 = new URL("url");
 	    URL url2 = new URL("file://");
+	    new File("D:/file.ext");
 	} catch (Exception e) {
 	    e.printStackTrace();
 	}

--- a/rules-reviewed/openshift/tests/data/LocalFileUsage.java
+++ b/rules-reviewed/openshift/tests/data/LocalFileUsage.java
@@ -65,6 +65,8 @@ public class LocalFileUsage {
 	    URL url1 = new URL("url");
 	    URL url2 = new URL("file://");
 	    new File("D:/file.ext");
+		doStuff(null, "c:\foo");
+		String[] paths = new String[]{"C:/s","D:/e","E:/f"};
 	} catch (Exception e) {
 	    e.printStackTrace();
 	}

--- a/rules-reviewed/openshift/tests/local-storage.windup.test.xml
+++ b/rules-reviewed/openshift/tests/local-storage.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="local-storage-test-00001">
                 <when>
                     <not>
-                        <iterable-filter size="32">
+                        <iterable-filter size="36">
                             <hint-exists message=".*Accessing a file on a local storage in a cloud environment is not safe because,.*" />
                         </iterable-filter>
                     </not>

--- a/rules-reviewed/openshift/tests/local-storage.windup.test.xml
+++ b/rules-reviewed/openshift/tests/local-storage.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="local-storage-test-00001">
                 <when>
                     <not>
-                        <iterable-filter size="29">
+                        <iterable-filter size="32">
                             <hint-exists message=".*Accessing a file on a local storage in a cloud environment is not safe because,.*" />
                         </iterable-filter>
                     </not>


### PR DESCRIPTION
- Enhancement for finding absolute Windows path so now the rule fires when:
  1. Properties file has a path definition (e.g. `: 'C:/`)
  1. String path is used to set a variable in Java (e.g. `= "C:/`)
  2. String path is used as argument for a method/constructor (e.g. `("C:/`)
- Fix bug about the escape in the `extensions`' pattern
- Update tests accordingly 