### PR TITLE
WINDUPRULE-289 Statistics Rules: Connect:EJB/CDI

### DIFF
--- a/rules-reviewed/technology-usage/ejb-technology-usage.windup.xml
+++ b/rules-reviewed/technology-usage/ejb-technology-usage.windup.xml
@@ -1,0 +1,70 @@
+<?xml version="1.0"?>
+<ruleset id="technology-usage-ejb" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides statistical summaries of the EJB/CDI items that were found during the analysis.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="weblogic" />
+        <targetTechnology id="eap"/>
+        <phase>PostMigrationRulesPhase</phase>
+    </metadata>
+    <rules>
+        <rule id="technology-usage-ejb-01000">
+            <when>
+                <graph-query discriminator="EjbSessionBean">
+                    <property name="sessionType">Stateless</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Stateless (SLSB)">
+                    <tag name="Connect"/>
+                    <tag name="Bean"/>
+                    <tag name="Java EE"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-ejb-01100">
+            <when>
+                <graph-query discriminator="EjbSessionBean">
+                    <property name="sessionType">Stateful</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Stateful (SFSB)">
+                    <tag name="Connect"/>
+                    <tag name="Bean"/>
+                    <tag name="Java EE"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-ejb-01200">
+            <when>
+                <graph-query discriminator="EjbMessageDriven"/>
+            </when>
+            <perform>
+                <technology-identified name="Message (MDB)">
+                    <tag name="Connect"/>
+                    <tag name="Bean"/>
+                    <tag name="Java EE"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-ejb-01300">
+            <when>
+                <graph-query discriminator="EjbEntityBean"/>
+            </when>
+            <perform>
+                <technology-identified name="Entity Bean">
+                    <tag name="Connect"/>
+                    <tag name="Bean"/>
+                    <tag name="Java EE"/>
+                </technology-identified>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/technology-usage/tests/data/ejb/SimpleQueueMDB.java
+++ b/rules-reviewed/technology-usage/tests/data/ejb/SimpleQueueMDB.java
@@ -1,0 +1,22 @@
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+@MessageDriven(
+        name = "SimpleQueueMDB",
+        activationConfig = {@ActivationConfigProperty(
+                propertyName = "destinationType",
+                propertyValue = "javax.jms.Queue"
+        ), @ActivationConfigProperty(
+                propertyName = "destination",
+                propertyValue = "queue/SimpleQueue"
+        ), @ActivationConfigProperty(
+                propertyName = "acknowledgeMode",
+                propertyValue = "Auto-acknowledge"
+        )}
+)
+public class SimpleQueueMDB implements MessageListener {
+    public void onMessage(Message message) {
+    }
+}

--- a/rules-reviewed/technology-usage/tests/data/ejb/SimpleStateful.java
+++ b/rules-reviewed/technology-usage/tests/data/ejb/SimpleStateful.java
@@ -1,0 +1,5 @@
+import javax.ejb.Stateful;
+
+@Stateful
+public class SimpleStateful {
+}

--- a/rules-reviewed/technology-usage/tests/data/ejb/SimpleStateless.java
+++ b/rules-reviewed/technology-usage/tests/data/ejb/SimpleStateless.java
@@ -1,0 +1,5 @@
+import javax.ejb.Stateless;
+
+@Stateless
+public class SimpleStateless {
+}

--- a/rules-reviewed/technology-usage/tests/data/ejb/SimpleTopicMDB.java
+++ b/rules-reviewed/technology-usage/tests/data/ejb/SimpleTopicMDB.java
@@ -1,0 +1,22 @@
+import javax.ejb.ActivationConfigProperty;
+import javax.ejb.MessageDriven;
+import javax.jms.Message;
+import javax.jms.MessageListener;
+
+@MessageDriven(
+        name = "SimpleTopicMDB",
+        activationConfig = {@ActivationConfigProperty(
+                propertyName = "destinationType",
+                propertyValue = "javax.jms.Topic"
+        ), @ActivationConfigProperty(
+                propertyName = "destination",
+                propertyValue = "topic/SimpleTopic"
+        ), @ActivationConfigProperty(
+                propertyName = "acknowledgeMode",
+                propertyValue = "Auto-acknowledge"
+        )}
+)
+public class SimpleTopicMDB implements MessageListener {
+    public void onMessage(Message rcvMessage) {
+    }
+}

--- a/rules-reviewed/technology-usage/tests/data/ejb/ejb-jar.xml
+++ b/rules-reviewed/technology-usage/tests/data/ejb/ejb-jar.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<!DOCTYPE ejb-jar PUBLIC '-//Sun Microsystems, Inc.//DTD Enterprise JavaBeans 2.0//EN' 'http://java.sun.com/dtd/ejb-jar_2_0.dtd'>
+<ejb-jar>
+    <enterprise-beans>
+        <session>
+            <ejb-name>testObject</ejb-name>
+            <home>testObjectHome</home>
+            <remote>TestObject</remote>
+            <ejb-class>TestObjectBean</ejb-class>
+            <session-type>Stateless</session-type>
+            <transaction-type>Container</transaction-type>
+        </session>
+        <entity>
+            <display-name>Gangster Entity Bean</display-name>
+            <ejb-name>GangsterEJB</ejb-name>
+            <local-home>org.jboss.cmp2.crimeportal.GangsterHome</local-home>
+            <local>org.jboss.cmp2.crimeportal.Gangster</local>
+
+            <ejb-class>org.jboss.cmp2.crimeportal.GangsterBean</ejb-class>
+            <persistence-type>Container</persistence-type>
+            <prim-key-class>java.lang.Integer</prim-key-class>
+            <reentrant>False</reentrant>
+            <cmp-version>2.x</cmp-version>
+            <abstract-schema-name>gangster</abstract-schema-name>
+
+            <cmp-field>
+                <field-name>gangsterId</field-name>
+            </cmp-field>
+            <cmp-field>
+                <field-name>name</field-name>
+            </cmp-field>
+            <cmp-field>
+                <field-name>nickName</field-name>
+            </cmp-field>
+            <cmp-field>
+                <field-name>badness</field-name>
+            </cmp-field>
+            <cmp-field>
+                <field-name>contactInfo</field-name>
+            </cmp-field>
+            <primkey-field>gangsterId</primkey-field>
+        </entity>
+    </enterprise-beans>
+    <assembly-descriptor>
+        <container-transaction>
+            <method>
+                <ejb-name>testObject</ejb-name>
+                <method-name>*</method-name>
+            </method>
+            <trans-attribute>Required</trans-attribute>
+        </container-transaction>
+    </assembly-descriptor>
+</ejb-jar>

--- a/rules-reviewed/technology-usage/tests/data/ejb/jboss-ejb3.xml
+++ b/rules-reviewed/technology-usage/tests/data/ejb/jboss-ejb3.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+               xmlns="http://java.sun.com/xml/ns/javaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+               version="3.1"
+               impl-version="2.1">
+    <enterprise-beans>
+        <session>
+            <ejb-name>testObject</ejb-name>
+            <session-type>Stateful</session-type>
+        </session>
+    </enterprise-beans>
+    <assembly-descriptor>
+    </assembly-descriptor>
+</jboss:ejb-jar>

--- a/rules-reviewed/technology-usage/tests/ejb-technology-usage.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/ejb-technology-usage.windup.test.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<ruletest id="technology-usage-ejb-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/ejb/</testDataPath>
+    <rulePath>../ejb-technology-usage.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="technology-usage-ejb-01000-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Stateless (SLSB)" number-found="2">
+                            <tag name="Connect"/>
+                            <tag name="Bean"/>
+                            <tag name="Java EE"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Stateless (SLSB) Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-ejb-01100-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Stateful (SFSB)" number-found="2">
+                            <tag name="Connect"/>
+                            <tag name="Bean"/>
+                            <tag name="Java EE"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Stateful (SFSB) Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-ejb-01200-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Message (MDB)" number-found="2">
+                            <tag name="Connect"/>
+                            <tag name="Bean"/>
+                            <tag name="Java EE"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Message (MDB) Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-ejb-01300-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Entity Bean" number-found="1">
+                            <tag name="Connect"/>
+                            <tag name="Bean"/>
+                            <tag name="Java EE"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Entity Bean Technology Statistic Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
Depends on windup/windup#1173

[WINDUPRULE-289](https://issues.jboss.org/browse/WINDUPRULE-289) requests to identify `Managed Beans (CDI)` but here the rule searches for `Entity Bean` just like what has been done in the dynamic EJB report.