### PR TITLE
WINDUPRULE-285 Statistics Rules: View:MVC

### DIFF
--- a/rules-reviewed/technology-usage/mvc-technology-usage.windup.xml
+++ b/rules-reviewed/technology-usage/mvc-technology-usage.windup.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0"?>
+<ruleset id="technology-usage-mvc" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides statistical summaries of the MVC (Spring MVC,Struts, Wicket, GWT) items that were found during the analysis.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <phase>PostMigrationRulesPhase</phase>
+    </metadata>
+    <rules>
+        <rule id="technology-usage-mvc-01000">
+            <when>
+                <graph-query discriminator="TechnologyTag">
+                    <property name="name">Apache Wicket (embedded)</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Wicket">
+                    <tag name="View"/>
+                    <tag name="Embedded"/>
+                    <tag name="MVC"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-mvc-01100">
+            <when>
+                <graph-query discriminator="TechnologyTag">
+                    <property name="name">Apache Struts (embedded)</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Struts">
+                    <tag name="View"/>
+                    <tag name="Embedded"/>
+                    <tag name="MVC"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-mvc-01200">
+            <when>
+                <graph-query discriminator="TechnologyTag">
+                    <property name="name">Spring MVC (embedded)</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Spring-MVC">
+                    <tag name="View"/>
+                    <tag name="Embedded"/>
+                    <tag name="MVC"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-mvc-01300">
+            <when>
+                <graph-query discriminator="TechnologyTag">
+                    <property name="name">GWT (embedded)</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="GWT">
+                    <tag name="View"/>
+                    <tag name="Embedded"/>
+                    <tag name="MVC"/>
+                </technology-identified>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/technology-usage/mvc-technology-usage.windup.xml
+++ b/rules-reviewed/technology-usage/mvc-technology-usage.windup.xml
@@ -14,7 +14,7 @@
     <rules>
         <rule id="technology-usage-mvc-01000">
             <when>
-                <graph-query discriminator="TechnologyTag">
+                <graph-query discriminator="TechnologyTagModel">
                     <property name="name">Apache Wicket (embedded)</property>
                 </graph-query>
             </when>
@@ -28,7 +28,7 @@
         </rule>
         <rule id="technology-usage-mvc-01100">
             <when>
-                <graph-query discriminator="TechnologyTag">
+                <graph-query discriminator="TechnologyTagModel">
                     <property name="name">Apache Struts (embedded)</property>
                 </graph-query>
             </when>
@@ -42,7 +42,7 @@
         </rule>
         <rule id="technology-usage-mvc-01200">
             <when>
-                <graph-query discriminator="TechnologyTag">
+                <graph-query discriminator="TechnologyTagModel">
                     <property name="name">Spring MVC (embedded)</property>
                 </graph-query>
             </when>
@@ -56,7 +56,7 @@
         </rule>
         <rule id="technology-usage-mvc-01300">
             <when>
-                <graph-query discriminator="TechnologyTag">
+                <graph-query discriminator="TechnologyTagModel">
                     <property name="name">GWT (embedded)</property>
                 </graph-query>
             </when>

--- a/rules-reviewed/technology-usage/mvc.windup.xml
+++ b/rules-reviewed/technology-usage/mvc.windup.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="mvc"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis of JSF libraries.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+    </metadata>
+    <rules>
+        <rule id="mvc-01000">
+            <when>
+                <file filename="{*}wicket{*}.jar"/>
+            </when>
+            <perform>
+                <classification title="Embedded library - Apache Wicket" category-id="optional" effort="0">
+                    <description>The application embeds an Apache Wicket library.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">Apache Wicket (embedded)</technology-tag>
+            </perform>
+        </rule>
+        <rule id="mvc-01100">
+            <when>
+                <file filename="{*}struts{*}.jar"/>
+            </when>
+            <perform>
+                <classification title="Embedded library - Apache Struts" category-id="optional" effort="0">
+                    <description>The application embeds an Apache Struts library.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">Apache Struts (embedded)</technology-tag>
+            </perform>
+        </rule>
+        <rule id="mvc-01200">
+            <when>
+                <file filename="{*}spring-webmvc{*}.jar"/>
+            </when>
+            <perform>
+                <classification title="Embedded library - Spring MVC" category-id="optional" effort="0">
+                    <description>The application embeds a Spring MVC library.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">Spring MVC (embedded)</technology-tag>
+            </perform>
+        </rule>
+        <rule id="mvc-01300">
+            <when>
+                <file filename="{*}gwt{*}.jar"/>
+            </when>
+            <perform>
+                <classification title="Embedded library - GWT" category-id="optional" effort="0">
+                    <description>The application embeds a GWT library.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">GWT (embedded)</technology-tag>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/technology-usage/tests/mvc-technology-usage.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/mvc-technology-usage.windup.test.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0"?>
+<ruletest id="technology-usage-mvc-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/mvc/</testDataPath>
+    <rulePath>../mvc-technology-usage.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="technology-usage-mvc-01000-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Wicket" number-found="1">
+                            <tag name="View"/>
+                            <tag name="Embedded"/>
+                            <tag name="MVC"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Wicket Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-mvc-01100-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Struts" number-found="1">
+                            <tag name="View"/>
+                            <tag name="Embedded"/>
+                            <tag name="MVC"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Struts Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-mvc-01200-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Spring-MVC" number-found="1">
+                            <tag name="View"/>
+                            <tag name="Embedded"/>
+                            <tag name="MVC"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Spring-MVC Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-mvc-01300-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="GWT" number-found="1">
+                            <tag name="View"/>
+                            <tag name="Embedded"/>
+                            <tag name="MVC"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="GWT Statistic Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/technology-usage/tests/mvc-technology-usage.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/mvc-technology-usage.windup.test.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <ruletest id="technology-usage-mvc-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
     <testDataPath>data/mvc/</testDataPath>
+    <rulePath>../mvc.windup.xml</rulePath>
     <rulePath>../mvc-technology-usage.windup.xml</rulePath>
     <ruleset>
         <rules>

--- a/rules-reviewed/technology-usage/tests/mvc.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/mvc.windup.test.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0"?>
+<ruletest id="mvc-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/mvc/</testDataPath>
+    <rulePath>../mvc.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="mvc-01000-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - Apache Wicket" />
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Wicket Classification Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01001-test">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="Apache Wicket \(embedded\)"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Wicket Technology Tag Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01100-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - Apache Struts" />
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Struts Classification Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01101-test">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="Apache Struts \(embedded\)"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Struts Technology Tag Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01200-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - Spring MVC" />
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Spring MVC Classification Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01201-test">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="Spring MVC \(embedded\)"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Spring MVC Technology Tag Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01300-test">
+                <when>
+                    <not>
+                        <classification-exists classification="Embedded library - GWT" />
+                    </not>
+                </when>
+                <perform>
+                    <fail message="GWT Classification Not Found" />
+                </perform>
+            </rule>
+            <rule id="mvc-01301-test">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="GWT \(embedded\)"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="GWT Technology Tag Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
Depends on windup/windup#1177
With the approach of searching for tags, the rules are quite simple and easy to create.
In this case, it searches for these MVC libraries:

- Spring MVC
- Struts (1 & 2)
- Wicket 
- GWT

The `myproject-1.0-SNAPSHOT.war` is a little bit heavy (7-8 MB) but it has inside 11 jars to test all the 4 frameworks.