### PR TITLE
WINDUPRULE-293 Statistics Rules: Clustering

### DIFF
--- a/rules-reviewed/technology-usage/clustering-technology-usage.windup.xml
+++ b/rules-reviewed/technology-usage/clustering-technology-usage.windup.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<ruleset id="technology-usage-clustering" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides statistical summaries of the clustering items that were found during the analysis.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <phase>PostMigrationRulesPhase</phase>
+    </metadata>
+    <rules>
+        <rule id="technology-usage-clustering-01000">
+            <when>
+                <graph-query discriminator="TechnologyTagModel">
+                    <property name="name">Clustering Web Session</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Web Session">
+                    <tag name="Sustain"/>
+                    <tag name="Java EE"/>
+                    <tag name="Clustering"/>
+                </technology-identified>
+            </perform>
+        </rule>
+        <rule id="technology-usage-clustering-02000">
+            <when>
+                <graph-query discriminator="TechnologyTagModel">
+                    <property name="name">Clustering EJB</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="EJB">
+                    <tag name="Sustain"/>
+                    <tag name="Java EE"/>
+                    <tag name="Clustering"/>
+                </technology-identified>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/technology-usage/clustering.windup.xml
+++ b/rules-reviewed/technology-usage/clustering.windup.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<ruleset id="clustering"
+    xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This is a simple ruleset for detecting usage of clustering technologies.
+        </description>
+        <dependencies>
+          <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final"/>
+          <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/>
+        </dependencies>
+    </metadata>
+    <rules>
+        <rule id="clustering-00000">
+            <when>
+              <xmlfile matches="/w:web-app/w:distributable">
+                  <namespace prefix="w" uri="http://java.sun.com/xml/ns/javaee"/>
+              </xmlfile>
+            </when>
+            <perform>
+                <technology-tag level="INFORMATIONAL">Clustering Web Session</technology-tag>
+            </perform>
+        </rule>
+        <rule id="clustering-00001">
+            <when>
+                <or>
+                    <javaclass references="org.jboss.ejb3.annotation.Clustered">
+                        <location>ANNOTATION</location>
+                        <location>IMPORT</location>
+                    </javaclass>
+                    <xmlfile matches="/*[local-name()='ejb-jar']/*[local-name()='assembly-descriptor']/*[local-name()='clustering']/*[local-name()='clustered']" />
+                    <xmlfile matches="/*[local-name()='jboss']/*[local-name()='enterprise-beans']/*[local-name()='session']/*[local-name()='clustered']" />
+                </or>
+            </when>
+            <perform>
+                <technology-tag level="INFORMATIONAL">Clustering EJB</technology-tag>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/technology-usage/tests/clustering-technology-usage.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/clustering-technology-usage.windup.test.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0"?>
+<ruletest id="technology-usage-clustering-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/clustering/</testDataPath>
+    <rulePath>../clustering.windup.xml</rulePath>
+    <rulePath>../clustering-technology-usage.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="technology-usage-clustering-01000-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Web Session" number-found="1">
+                            <tag name="Sustain"/>
+                            <tag name="Java EE"/>
+                            <tag name="Clustering"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Web Session Technology Statistic Not Found" />
+                </perform>
+            </rule>
+            <rule id="technology-usage-clustering-01000-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="EJB" number-found="1">
+                            <tag name="Sustain"/>
+                            <tag name="Java EE"/>
+                            <tag name="Clustering"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="EJB Technology Statistic Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/technology-usage/tests/clustering.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/clustering.windup.test.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruletest id="clustering-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/clustering</testDataPath>
+    <rulePath>../clustering.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="clustering-test-00000">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="Clustering Web Session"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="'distributable' Technology Tag Not Found" />
+                </perform>
+            </rule>
+            <rule id="clustering-test-00001">
+                <when>
+                    <not>
+                        <technology-tag-exists technology-tag="Clusteing EJB"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="'Clustered' Technology Tag Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/technology-usage/tests/clustering.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/clustering.windup.test.xml
@@ -17,7 +17,7 @@
             <rule id="clustering-test-00001">
                 <when>
                     <not>
-                        <technology-tag-exists technology-tag="Clusteing EJB"/>
+                        <technology-tag-exists technology-tag="Clustering EJB"/>
                     </not>
                 </when>
                 <perform>

--- a/rules-reviewed/technology-usage/tests/data/clustering/ClusteredExample.java
+++ b/rules-reviewed/technology-usage/tests/data/clustering/ClusteredExample.java
@@ -1,0 +1,7 @@
+import org.jboss.ejb3.annotation.Clustered;
+
+public class ClusteredExample
+{
+    @Clustered
+    private String field;
+}

--- a/rules-reviewed/technology-usage/tests/data/clustering/jboss-ejb3.xml
+++ b/rules-reviewed/technology-usage/tests/data/clustering/jboss-ejb3.xml
@@ -1,0 +1,28 @@
+<?xml version="1.1" encoding="UTF-8"?>
+<jboss:ejb-jar xmlns:jboss="http://www.jboss.com/xml/ns/javaee"
+               xmlns="http://java.sun.com/xml/ns/javaee"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xmlns:c="urn:clustering:1.0"
+               xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss-ejb3-2_0.xsd http://java.sun.com/xml/ns/javaee http://java.sun.com/xml/ns/javaee/ejb-jar_3_1.xsd"
+               version="3.1"
+               impl-version="2.0">
+    <enterprise-beans>
+        <message-driven>
+            <ejb-name>ReplyingMDB</ejb-name>
+            <ejb-class>org.jboss.as.test.integration.ejb.mdb.messagedestination.ReplyingMDB</ejb-class>
+            <activation-config>
+                <activation-config-property>
+                    <activation-config-property-name>destination</activation-config-property-name>
+                    <activation-config-property-value>java:jboss/mdbtest/messageDestinationQueue
+                    </activation-config-property-value>
+                </activation-config-property>
+            </activation-config>
+        </message-driven>
+    </enterprise-beans>
+    <assembly-descriptor>
+        <c:clustering>
+            <ejb-name>DDBasedClusteredSFSB</ejb-name>
+            <c:clustered>true</c:clustered>
+        </c:clustering>
+    </assembly-descriptor>
+</jboss:ejb-jar>

--- a/rules-reviewed/technology-usage/tests/data/clustering/jboss.xml
+++ b/rules-reviewed/technology-usage/tests/data/clustering/jboss.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE jboss PUBLIC "-//JBoss//DTD JBOSS 2.4//EN" "http://www.jboss.org/j2ee/dtd/jboss_2_4.dtd">
+<jboss xmlns="http://www.jboss.com/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.jboss.com/xml/ns/javaee http://www.jboss.org/j2ee/schema/jboss_5_1.xsd" version="5.1">
+
+    <security-domain>java:/jaas/customAdmin</security-domain>
+
+    <enterprise-beans>
+        <session>
+            <ejb-name>ShoppingCart</ejb-name>
+            <jndi-name>ShoppingCart</jndi-name>
+            <clustered>true</clustered>
+            <cluster-config>
+                <partition-name>DefaultPartition</partition-name>
+                <load-balance-policy>
+                    org.jboss.ha.framework.interfaces.RandomRobin
+                </load-balance-policy>
+            </cluster-config>
+            <security-domain>tutorial-test</security-domain>
+        </session>
+        <session>
+            <ejb-name>StatelessTest</ejb-name>
+            <jndi-name>StatelessTest</jndi-name>
+        </session>
+        <session>
+            <ejb-name>CustomConfigBean</ejb-name>
+            <pool-config>
+                <pool-value>StrictMaxPool</pool-value>
+                <pool-max-size>10</pool-max-size>
+                <pool-timeout>30002</pool-timeout>
+            </pool-config>
+        </session>
+    </enterprise-beans>
+
+    <assembly-descriptor>
+        <security-role>
+            <role-name>customUser</role-name>
+            <principal-name>customUser</principal-name>
+        </security-role>
+        <security-role>
+            <role-name>customAdmin</role-name>
+            <principal-name>customAdmin</principal-name>
+        </security-role>
+    </assembly-descriptor>
+
+</jboss>

--- a/rules-reviewed/technology-usage/tests/data/clustering/web.xml
+++ b/rules-reviewed/technology-usage/tests/data/clustering/web.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<web-app version="3.0" xmlns="http://java.sun.com/xml/ns/javaee" 
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+  xsi:schemaLocation="http://java.sun.com/xml/ns/javaee 
+  http://java.sun.com/xml/ns/javaee/web-app_3_0.xsd">
+
+      <distributable/>
+
+</web-app>


### PR DESCRIPTION
Create rules to add statistics for the following technologies:

- Web Session
- EJB

JPA should also been taken into account but searching for clustering is not standard JPA but based on the specific framework used (e.g. Hibernate, EclipseLink) so it's not be included in this PR waiting for more details about it.