### PR TITLE
WINDUPRULE-301 WS-Security Changes in JBoss EAP 7

### DIFF
--- a/rules-reviewed/eap7/eap6/tests/data/data-ws-security/PWCallback.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-ws-security/PWCallback.java
@@ -1,0 +1,43 @@
+import java.io.IOException;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.apache.ws.security.WSPasswordCallback;
+
+public class PWCallback implements CallbackHandler {
+
+    private static final byte[] key = {
+            (byte)0x31, (byte)0xfd, (byte)0xcb, (byte)0xda,
+            (byte)0xfb, (byte)0xcd, (byte)0x6b, (byte)0xa8,
+            (byte)0xe6, (byte)0x19, (byte)0xa7, (byte)0xbf,
+            (byte)0x51, (byte)0xf7, (byte)0xc7, (byte)0x3e,
+            (byte)0x80, (byte)0xae, (byte)0x98, (byte)0x51,
+            (byte)0xc8, (byte)0x51, (byte)0x34, (byte)0x04,
+    };
+
+    public void handle(Callback[] callbacks)
+            throws IOException, UnsupportedCallbackException {
+        for (int i = 0; i < callbacks.length; i++) {
+            if (callbacks[i] instanceof WSPasswordCallback) {
+                WSPasswordCallback pc = (WSPasswordCallback) callbacks[i];
+        /*
+         * here call a function/method to lookup the password for
+         * the given identifier (e.g. a user name or keystore alias)
+         * e.g.: pc.setPassword(passStore.getPassword(pc.getIdentfifier))
+         * for testing we supply a fixed name/fixed key here.
+         */
+                if (pc.getUsage() == WSPasswordCallback.KEY_NAME) {
+                    pc.setKey(key);
+                }
+                else {
+                    pc.setPassword("security");
+                }
+            } else {
+                throw new UnsupportedCallbackException(
+                        callbacks[i], "Unrecognized Callback");
+            }
+        }
+    }
+}

--- a/rules-reviewed/eap7/eap6/tests/data/data-ws-security/SAMLIssuerImpl.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-ws-security/SAMLIssuerImpl.java
@@ -1,0 +1,260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import org.apache.ws.security.WSSecurityException;
+import org.apache.ws.security.components.crypto.Crypto;
+import org.apache.ws.security.components.crypto.CryptoFactory;
+
+import org.apache.ws.security.saml.ext.AssertionWrapper;
+import org.apache.ws.security.saml.ext.SAMLParms;
+import org.apache.ws.security.util.Loader;
+
+import java.util.Properties;
+
+import javax.security.auth.callback.CallbackHandler;
+
+/**
+ * Builds a WS SAML Assertion and inserts it into the SOAP Envelope. Refer to
+ * the WS specification, SAML Token profile
+ */
+public class SAMLIssuerImpl implements SAMLIssuer {
+
+    private static final org.apache.commons.logging.Log LOG =
+            org.apache.commons.logging.LogFactory.getLog(SAMLIssuerImpl.class);
+
+    private Properties properties = null;
+
+    private CallbackHandler callbackHandler = null;
+
+    private String issuer;
+    private Crypto issuerCrypto = null;
+    private String issuerKeyPassword = null;
+    private String issuerKeyName = null;
+
+    /**
+     * Flag indicating what format to put the subject's key material in when
+     * NOT using Sender Vouches as the confirmation method.  The default is
+     * to use ds:X509Data and include the entire certificate.  If this flag
+     * is set to true, a ds:KeyValue is used instead with just the key material.
+     */
+    private boolean sendKeyValue = false;
+
+    /**
+     * This boolean controls whether the assertion is to be signed or not
+     */
+    private boolean signAssertion = false;
+
+    /**
+     * Constructor.
+     */
+    public SAMLIssuerImpl() {
+    }
+
+    public SAMLIssuerImpl(Properties prop) throws WSSecurityException {
+        /*
+         * if no properties .. just return an instance, the rest will be done
+         * later or this instance is just used to handle certificate
+         * conversions in this implementation
+         */
+        if (prop == null) {
+            return;
+        }
+        properties = prop;
+
+        String cryptoProp =
+                properties.getProperty("org.apache.ws.security.saml.issuer.cryptoProp.file");
+        if (cryptoProp != null) {
+            issuerCrypto = CryptoFactory.getInstance(cryptoProp);
+            issuerKeyName =
+                    properties.getProperty("org.apache.ws.security.saml.issuer.key.name");
+            issuerKeyPassword =
+                    properties.getProperty("org.apache.ws.security.saml.issuer.key.password");
+        }
+
+        String sendKeyValueProp =
+                properties.getProperty("org.apache.ws.security.saml.issuer.sendKeyValue");
+        if (sendKeyValueProp != null) {
+            sendKeyValue = Boolean.valueOf(sendKeyValueProp).booleanValue();
+        }
+
+        String signAssertionProp =
+                properties.getProperty("org.apache.ws.security.saml.issuer.signAssertion");
+        if (signAssertionProp != null) {
+            signAssertion = Boolean.valueOf(signAssertionProp).booleanValue();
+        }
+
+        String issuerProp = properties.getProperty("org.apache.ws.security.saml.issuer");
+        if (issuerProp != null) {
+            issuer = issuerProp;
+        }
+    }
+
+    /**
+     * Creates a new AssertionWrapper.
+     *
+     * @return a new AssertionWrapper.
+     */
+    public AssertionWrapper newAssertion() throws WSSecurityException {
+        if (LOG.isDebugEnabled()) {
+            LOG.debug(
+                    "Entering AssertionWrapper.newAssertion() ... creating SAML token"
+            );
+        }
+
+        if (callbackHandler == null && properties != null) {
+            try {
+                String samlCallbackClassname =
+                        properties.getProperty("org.apache.ws.security.saml.callback");
+                Class<? extends CallbackHandler> callbackClass = null;
+                try {
+                    callbackClass = Loader.loadClass(samlCallbackClassname, CallbackHandler.class);
+                } catch (ClassNotFoundException ex) {
+                    throw new WSSecurityException(ex.getMessage(), ex);
+                }
+                callbackHandler = callbackClass.newInstance();
+            } catch (InstantiationException ex) {
+                throw new WSSecurityException(ex.getMessage(), ex);
+            } catch (IllegalAccessException ex) {
+                throw new WSSecurityException(ex.getMessage(), ex);
+            }
+        }
+
+        // Create a new SAMLParms with all of the information from the properties file.
+        SAMLParms samlParms = new SAMLParms();
+        samlParms.setIssuer(issuer);
+        samlParms.setCallbackHandler(callbackHandler);
+
+        AssertionWrapper sa = new AssertionWrapper(samlParms);
+        if (signAssertion) {
+            sa.signAssertion(issuerKeyName, issuerKeyPassword, issuerCrypto, sendKeyValue);
+        }
+
+        return sa;
+    }
+
+    /**
+     * Set whether to send the key value or whether to include the entire cert.
+     * @param sendKeyValue whether to send the key value.
+     */
+    public void setSendKeyValue(boolean sendKeyValue) {
+        this.sendKeyValue = sendKeyValue;
+    }
+
+    /**
+     * Get whether to send the key value or whether to include the entire cert.
+     * @return whether to send the key value
+     */
+    public boolean isSendKeyValue() {
+        return sendKeyValue;
+    }
+
+    /**
+     * Set whether to sign the assertion or not.
+     * @param signAssertion whether to sign the assertion or not.
+     */
+    public void setSignAssertion(boolean signAssertion) {
+        this.signAssertion = signAssertion;
+    }
+
+    /**
+     * Get whether to sign the assertion or not
+     * @return whether to sign the assertion or not
+     */
+    public boolean isSignAssertion() {
+        return signAssertion;
+    }
+
+    /**
+     * Set the CallbackHandler to use
+     * @param callbackHandler the CallbackHandler to use
+     */
+    public void setCallbackHandler(CallbackHandler callbackHandler) {
+        this.callbackHandler = callbackHandler;
+    }
+
+    /**
+     * Get the CallbackHandler in use
+     * @return the CallbackHandler in use
+     */
+    public CallbackHandler getCallbackHandler() {
+        return callbackHandler;
+    }
+
+    /**
+     * Set the issuer crypto
+     * @param issuerCrypto the issuer crypto
+     */
+    public void setIssuerCrypto(Crypto issuerCrypto) {
+        this.issuerCrypto = issuerCrypto;
+    }
+
+    /**
+     * @return Returns the issuerCrypto.
+     */
+    public Crypto getIssuerCrypto() {
+        return issuerCrypto;
+    }
+
+    /**
+     * Set the issuer name
+     * @param issuer the issuer name
+     */
+    public void setIssuerName(String issuer) {
+        this.issuer = issuer;
+    }
+
+    /**
+     * Get the issuer name
+     * @return the issuer name
+     */
+    public String getIssuerName() {
+        return issuer;
+    }
+
+    /**
+     * Set the issuer key name
+     * @param issuerKeyName the issuer key name
+     */
+    public void setIssuerKeyName(String issuerKeyName) {
+        this.issuerKeyName = issuerKeyName;
+    }
+
+    /**
+     * @return Returns the issuerKeyName.
+     */
+    public String getIssuerKeyName() {
+        return issuerKeyName;
+    }
+
+    /**
+     * Set the issuer key password
+     * @param issuerKeyPassword the issuerKeyPassword.
+     */
+    public void setIssuerKeyPassword(String issuerKeyPassword) {
+        this.issuerKeyPassword = issuerKeyPassword;
+    }
+
+    /**
+     * @return Returns the issuerKeyPassword.
+     */
+    public String getIssuerKeyPassword() {
+        return issuerKeyPassword;
+    }
+
+}

--- a/rules-reviewed/eap7/eap6/tests/data/data-ws-security/SamlCallbackHandler.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-ws-security/SamlCallbackHandler.java
@@ -1,0 +1,120 @@
+import java.io.IOException;
+import java.io.InputStream;
+import java.security.cert.X509Certificate;
+import java.util.Collections;
+import java.util.Properties;
+
+import javax.security.auth.callback.Callback;
+import javax.security.auth.callback.CallbackHandler;
+import javax.security.auth.callback.UnsupportedCallbackException;
+
+import org.apache.ws.security.components.crypto.Crypto;
+import org.apache.ws.security.components.crypto.CryptoFactory;
+import org.apache.ws.security.components.crypto.CryptoType;
+import org.apache.ws.security.saml.ext.SAMLCallback;
+import org.apache.ws.security.saml.ext.bean.AttributeBean;
+import org.apache.ws.security.saml.ext.bean.AttributeStatementBean;
+import org.apache.ws.security.saml.ext.bean.KeyInfoBean;
+import org.apache.ws.security.saml.ext.bean.KeyInfoBean.CERT_IDENTIFIER;
+import org.apache.ws.security.saml.ext.bean.SubjectBean;
+import org.apache.ws.security.saml.ext.builder.SAML1Constants;
+import org.apache.ws.security.saml.ext.builder.SAML2Constants;
+import org.opensaml.common.SAMLVersion;
+
+public class SamlCallbackHandler implements CallbackHandler
+{
+    private String confirmationMethod = SAML2Constants.CONF_BEARER;
+
+    private boolean saml2;
+
+    public SamlCallbackHandler()
+    {
+    }
+
+    public void setConfirmationMethod(String confirmationMethod)
+    {
+        this.confirmationMethod = confirmationMethod;
+    }
+
+    public void setSaml2(boolean isSaml2)
+    {
+        this.saml2 = isSaml2;
+    }
+
+    public void handle(Callback[] callbacks) throws IOException, UnsupportedCallbackException
+    {
+        for (int i = 0; i < callbacks.length; i++)
+        {
+            if (callbacks[i] instanceof SAMLCallback)
+            {
+                SAMLCallback callback = (SAMLCallback) callbacks[i];
+                if (this.saml2)
+                {
+                    callback.setSamlVersion(SAMLVersion.VERSION_20);
+                }
+                callback.setIssuer("sts");
+                String subjectName = "uid=sts-client,o=jbws-cxf-sts.com";
+                String subjectQualifier = "www.jbws-cxf-sts.org";
+
+                SubjectBean subjectBean = new SubjectBean(subjectName, subjectQualifier, this.confirmationMethod);
+                if (SAML2Constants.CONF_HOLDER_KEY.equals(this.confirmationMethod)
+                        || SAML1Constants.CONF_HOLDER_KEY.equals(this.confirmationMethod))
+                {
+                    try
+                    {
+                        KeyInfoBean keyInfo = createKeyInfo();
+                        subjectBean.setKeyInfo(keyInfo);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new IOException("Problem creating KeyInfo: " + ex.getMessage());
+                    }
+                }
+
+                callback.setSubject(subjectBean);
+
+                AttributeStatementBean attrBean = new AttributeStatementBean();
+                attrBean.setSubject(subjectBean);
+
+                AttributeBean attributeBean = new AttributeBean();
+                if (this.saml2)
+                {
+                    attributeBean.setQualifiedName("subject-role");
+                }
+                else
+                {
+                    attributeBean.setSimpleName("subject-role");
+                    attributeBean.setQualifiedName("http://custom-ns");
+                }
+                attributeBean.setAttributeValues(Collections.singletonList("system-user"));
+                attrBean.setSamlAttributes(Collections.singletonList(attributeBean));
+                callback.setAttributeStatementData(Collections.singletonList(attrBean));
+            }
+        }
+    }
+
+    protected KeyInfoBean createKeyInfo() throws Exception
+    {
+        InputStream is = Thread.currentThread().getContextClassLoader().getResource("META-INF/alice.properties").openStream();
+        Properties props = new Properties();
+        try
+        {
+            props.load(is);
+        }
+        finally
+        {
+            is.close();
+        }
+        Crypto crypto = CryptoFactory.getInstance(props);
+        CryptoType cryptoType = new CryptoType(CryptoType.TYPE.ALIAS);
+        cryptoType.setAlias("alice");
+        X509Certificate[] certs = crypto.getX509Certificates(cryptoType);
+
+        KeyInfoBean keyInfo = new KeyInfoBean();
+        keyInfo.setCertificate(certs[0]);
+        keyInfo.setCertIdentifer(CERT_IDENTIFIER.X509_CERT);
+
+        return keyInfo;
+    }
+
+}

--- a/rules-reviewed/eap7/eap6/tests/ws-security.windup.test.xml
+++ b/rules-reviewed/eap7/eap6/tests/ws-security.windup.test.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="ws-security-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/data-ws-security/</testDataPath>
+    <rulePath>../ws-security.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+           <rule id="ws-security-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The `org.apache.ws.security.WSPasswordCallback` class has moved to package `org.apache.wss4j.common.ext`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="The hint about changed value of WSPasswordCallback's package changed not found!"/>
+                </perform>
+            </rule>
+           <rule id="ws-security-00001-test">
+                <when>
+                    <not>
+                        <iterable-filter size="8">
+                            <hint-exists message="Most of the SAML bean objects from the `org.apache.ws.security.saml.ext` package have been moved to the `org.apache.wss4j.common.saml` package"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="The hint about changed value of SAML bean objects' package changed not found!"/>
+                </perform>
+            </rule>
+           <rule id="ws-security-00002-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The `org.apache.ws.security.saml.ext.AssertionWrapper` class have been renamed and moved to the `org.apache.wss4j.common.saml.SamlAssertionWrapper` class"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="The hint about renamed and moved AssertionWrapper class not found!"/>
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/eap7/eap6/ws-security.windup.xml
+++ b/rules-reviewed/eap7/eap6/ws-security.windup.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="ws-security"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+
+    <metadata>
+        <description>
+            This ruleset provides analysis of applications that use WS-Security and may require
+            individual attention when migrating to JBoss EAP 7+.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="eap" versionRange="[6,7)" />
+        <targetTechnology id="eap" versionRange="[7,)" />
+    </metadata>
+
+    <rules>
+        <rule id="ws-security-00000">
+            <when>
+                <javaclass references="org.apache.ws.security.WSPasswordCallback">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="WS-Security WSPasswordCallback's package changed" effort="1" category-id="mandatory">
+                    <message>
+                        The `org.apache.ws.security.WSPasswordCallback` class has moved to package `org.apache.wss4j.common.ext`.
+                        The application must be changed to reference to the new package.
+                    </message>
+                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_ws_security_changes" title="WS-Security Changes"/>
+                    <tag>ws-security</tag>
+                    <quickfix type="REPLACE" name="WSPasswordCallback">
+                        <replacement>org.apache.wss4j.common.ext.WSPasswordCallback</replacement>
+                        <search>org.apache.ws.security.WSPasswordCallback</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
+        <rule id="ws-security-00001">
+            <when>
+                <javaclass references="org.apache.ws.security.saml.ext.{SAMLClassAndPackages}{*}">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="WS-Security SAML package changed" effort="1" category-id="mandatory">
+                    <message>
+                        Most of the SAML bean objects from the `org.apache.ws.security.saml.ext` package have been moved to the `org.apache.wss4j.common.saml` package.
+                        The application must be changed to reference to the new package.
+                    </message>
+                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_ws_security_changes" title="WS-Security Changes"/>
+                    <tag>ws-security</tag>
+                    <quickfix type="REPLACE" name="SAML_package">
+                        <replacement>org.apache.wss4j.common.saml</replacement>
+                        <search>org.apache.ws.security.saml.ext</search>
+                    </quickfix>
+                </hint>
+            </perform>
+            <where param="SAMLClassAndPackages" >
+                <matches pattern="(bean.|builder.|OpenSAMLBootstrap|OpenSAMLUtil|SAMLCallback)" />
+            </where>
+        </rule>
+        <rule id="ws-security-00002">
+            <when>
+                <javaclass references="org.apache.ws.security.saml.ext.AssertionWrapper">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="WS-Security AssertionWrapper renamed and moved" effort="1" category-id="mandatory">
+                    <message>
+                        The `org.apache.ws.security.saml.ext.AssertionWrapper` class have been renamed and moved to the `org.apache.wss4j.common.saml.SamlAssertionWrapper` class.
+                        The application must be changed to reference and use the new class.
+                    </message>
+                    <link href="https://access.redhat.com/webassets/avalon/d/red-hat-jboss-enterprise-application-platform/7.0.0/javadocs/org/apache/wss4j/common/saml/SamlAssertionWrapper.html" title="Javadoc SamlAssertionWrapper"/>
+                    <tag>ws-security</tag>
+                    <quickfix type="REPLACE" name="SAML_package">
+                        <replacement>org.apache.wss4j.common.saml.SamlAssertionWrapper</replacement>
+                        <search>org.apache.ws.security.saml.ext.AssertionWrapper</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>


### PR DESCRIPTION
There are the 2 rules as from JIRA requested in [WINDUPRULE-301](https://issues.jboss.org/browse/WINDUPRULE-301).

There's also a third rule because i found that [`org.apache.ws.security.saml.ext.AssertionWrapper`](https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/API_Documentation/files/javadoc/org/apache/ws/security/saml/ext/AssertionWrapper.html) has been deleted and, it seems, replaced by [`org.apache.wss4j.common.saml.SamlAssertionWrapper`](https://access.redhat.com/webassets/avalon/d/red-hat-jboss-enterprise-application-platform/7.0.0/javadocs/org/apache/wss4j/common/saml/SamlAssertionWrapper.html) class even if there's no 1:1 relation between the methods in the 2 classes.

@mareknovotny and @emmartins do you think we can have this third rule as well or it's better to remove it from this PR?