### PR TITLE
WINDUPRULE-302 JAX-WS 2.2 Requirements for WebServiceRef

### DIFF
--- a/rules-reviewed/eap7/eap6/jax-ws.windup.xml
+++ b/rules-reviewed/eap7/eap6/jax-ws.windup.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="jax-ws"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+
+    <metadata>
+        <description>
+            This ruleset provides analysis of applications that use JAX-WS and may require
+            individual attention when migrating to JBoss EAP 7+.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="eap" versionRange="[6,7)" />
+        <targetTechnology id="eap" versionRange="[7,)" />
+    </metadata>
+
+    <rules>
+        <rule id="jax-ws-00000">
+            <when>
+                <and>
+                    <javaclass references="javax.xml.ws.Service" as="default">
+                        <location>INHERITANCE</location>
+                    </javaclass>
+                    <not>
+                        <javaclass from="default" references="{*}(java.net.URL, javax.xml.namespace.QName, javax.xml.ws.WebServiceFeature)"/>
+                    </not>
+                </and>
+            </when>
+            <perform>
+                <hint title="JAX-WS 2.2 Requirements for WebServiceRef" effort="1" category-id="optional">
+                    <message>
+                        Containers must use JAX-WS 2.2 style constructors, using the WebServiceFeature class, to build clients that are injected into web service references.
+                        This means that user provided service classes injected by the container must implement JAX-WS 2.2 or later.
+                        The application must be changed to reference to the new package.
+                    </message>
+                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_jax_ws_2_2_requirements_for_webserviceref" title="JAX-WS 2.2 Requirements for WebServiceRef"/>
+                    <tag>jax-ws</tag>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/eap7/eap6/jax-ws.windup.xml
+++ b/rules-reviewed/eap7/eap6/jax-ws.windup.xml
@@ -12,32 +12,41 @@
             <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
-        <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="eap" versionRange="[7,)" />
     </metadata>
-
     <rules>
         <rule id="jax-ws-00000">
             <when>
-                <and>
-                    <javaclass references="javax.xml.ws.Service" as="default">
-                        <location>INHERITANCE</location>
-                    </javaclass>
-                    <not>
-                        <javaclass from="default" references="{*}(java.net.URL, javax.xml.namespace.QName, javax.xml.ws.WebServiceFeature)"/>
-                    </not>
-                </and>
+                <javaclass references="javax.xml.ws.Service" as="step1">
+                    <location>INHERITANCE</location>
+                </javaclass>
+                <javaclass references="{*}(java.net.URL, javax.xml.namespace.QName)" from="step1" as="step2">
+                    <location>METHOD</location>
+                </javaclass>
             </when>
             <perform>
-                <hint title="JAX-WS 2.2 Requirements for WebServiceRef" effort="1" category-id="optional">
-                    <message>
-                        Containers must use JAX-WS 2.2 style constructors, using the WebServiceFeature class, to build clients that are injected into web service references.
-                        This means that user provided service classes injected by the container must implement JAX-WS 2.2 or later.
-                        The application must be changed to reference to the new package.
-                    </message>
-                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_jax_ws_2_2_requirements_for_webserviceref" title="JAX-WS 2.2 Requirements for WebServiceRef"/>
-                    <tag>jax-ws</tag>
-                </hint>
+                <iteration over="step2">
+                    <when>
+                        <not>
+                            <javaclass references="{*}(java.net.URL, javax.xml.namespace.QName, javax.xml.ws.WebServiceFeature{*})">
+                                <location>METHOD</location>
+                            </javaclass>
+                        </not>
+                    </when>
+                    <perform>
+                        <hint title="JAX-WS 2.2 Requirements for WebServiceRef" effort="1" category-id="mandatory">
+                            <message>
+                                <![CDATA[
+                                EAP 7 uses JAX-WS 2.2 style constructors with the `javax.xml.ws.WebServiceFeature` class to build clients that are injected into web service references (i.e. using the `@WebServiceRef` annotation).  
+                                This means that user provided service classes injected by the container must implement JAX-WS 2.2 or later.  
+                                The class must be changed to add the constructor [`Service(URL wsdlDocumentLocation, QName serviceName, WebServiceFeature... features)`](https://docs.oracle.com/javase/7/docs/api/javax/xml/ws/Service.html#Service&#40;java.net.URL,%20javax.xml.namespace.QName,%20javax.xml.ws.WebServiceFeature...&#41;)
+                                ]]>
+                            </message>
+                            <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_jax_ws_2_2_requirements_for_webserviceref" title="JAX-WS 2.2 Requirements for WebServiceRef"/>
+                            <tag>jax-ws</tag>
+                        </hint>
+                    </perform>
+                </iteration>
             </perform>
         </rule>
     </rules>

--- a/rules-reviewed/eap7/eap6/tests/data/data-jax-ws/HelloWorldImplService.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-jax-ws/HelloWorldImplService.java
@@ -1,0 +1,21 @@
+import java.net.MalformedURLException;
+import java.net.URL;
+import javax.xml.namespace.QName;
+import javax.xml.ws.Service;
+import javax.xml.ws.WebEndpoint;
+import javax.xml.ws.WebServiceClient;
+import javax.xml.ws.WebServiceFeature;
+
+@WebServiceClient(name = "HelloWorldImplService", targetNamespace = "http://ws.example.com/")
+public class HelloWorldImplService extends Service
+{
+
+    public HelloWorldImplService(URL wsdlLocation, QName serviceName) {
+        super(wsdlLocation, serviceName);
+    }
+
+    public HelloWorldImplService(URL wsdlLocation, QName serviceName, WebServiceFeature... features) {
+        super(wsdlLocation, serviceName, features);
+    }
+
+}

--- a/rules-reviewed/eap7/eap6/tests/data/data-jax-ws/RestaurantServiceATService.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-jax-ws/RestaurantServiceATService.java
@@ -1,0 +1,60 @@
+import javax.xml.namespace.QName;
+import javax.xml.ws.Service;
+import javax.xml.ws.WebEndpoint;
+import javax.xml.ws.WebServiceClient;
+import javax.xml.ws.WebServiceFeature;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.logging.Logger;
+
+@WebServiceClient(name = "RestaurantServiceATService", targetNamespace = "http://www.jboss.org/jboss-jdf/jboss-as-quickstart/wsat/simple/Restaurant")
+public class RestaurantServiceATService extends Service {
+    private final static URL RESTAURANTSERVICEATSERVICE_WSDL_LOCATION;
+    private final static Logger logger = Logger.getLogger(RestaurantServiceATService.class.getName());
+
+    static {
+        URL url = null;
+        try {
+            URL baseUrl;
+            baseUrl = RestaurantServiceATService.class.getResource(".");
+            url = new URL(baseUrl, "RestaurantServiceAT.wsdl");
+        } catch (MalformedURLException e) {
+            logger.warning("Failed to create URL for the wsdl Location: 'RestaurantServiceAT.wsdl', retrying as a local file");
+            logger.warning(e.getMessage());
+        }
+        RESTAURANTSERVICEATSERVICE_WSDL_LOCATION = url;
+    }
+
+    public RestaurantServiceATService(URL wsdlLocation, QName serviceName) {
+        super(wsdlLocation, serviceName);
+    }
+
+    public RestaurantServiceATService() {
+        super(RESTAURANTSERVICEATSERVICE_WSDL_LOCATION, new QName(
+                "http://www.jboss.org/jboss-jdf/jboss-as-quickstart/wsat/simple/Restaurant", "RestaurantServiceATService"));
+    }
+
+    *
+     *
+     * @return returns RestaurantServiceAT
+
+    @WebEndpoint(name = "RestaurantServiceAT")
+    public RestaurantServiceAT getRestaurantServiceAT() {
+        return super.getPort(new QName("http://www.jboss.org/jboss-jdf/jboss-as-quickstart/wsat/simple/Restaurant",
+                "RestaurantServiceAT"), RestaurantServiceAT.class);
+    }
+
+    *
+     *
+     * @param features A list of {@link javax.xml.ws.WebServiceFeature} to configure on the proxy. Supported features not in the
+     *        <code>features</code> parameter will have their default values.
+     * @return returns RestaurantServiceAT
+
+    @WebEndpoint(name = "RestaurantServiceAT")
+    public RestaurantServiceAT getRestaurantServiceAT(WebServiceFeature... features) {
+        return super.getPort(new QName("http://www.jboss.org/jboss-jdf/jboss-as-quickstart/wsat/simple/Restaurant",
+                "RestaurantServiceAT"), RestaurantServiceAT.class, features);
+    }
+
+}

--- a/rules-reviewed/eap7/eap6/tests/jax-ws.windup.test.xml
+++ b/rules-reviewed/eap7/eap6/tests/jax-ws.windup.test.xml
@@ -9,7 +9,7 @@
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="Containers must use JAX-WS 2.2 style constructors"/>
+                            <hint-exists message="EAP 7 uses JAX-WS 2.2 style constructors"/>
                         </iterable-filter>
                     </not>
                 </when>

--- a/rules-reviewed/eap7/eap6/tests/jax-ws.windup.test.xml
+++ b/rules-reviewed/eap7/eap6/tests/jax-ws.windup.test.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="jax-ws-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/data-jax-ws/</testDataPath>
+    <rulePath>../jax-ws.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="jax-ws-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="Containers must use JAX-WS 2.2 style constructors"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="The hint about changed value of WebServiceRef not found!"/>
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
The issue to address is:
"_Containers must use JAX-WS 2.2 style constructors, using the WebServiceFeature class, to build clients that are injected into web service references. This means that user provided service classes injected by the container must implement JAX-WS 2.2 or later._"
so the rule checks for classes that extends [javax.xml.ws.Service](http://docs.oracle.com/javaee/7/api/javax/xml/ws/Service.html) (in Java EE 7) that has not a constructor with [javax.xml.ws.WebServiceFeature](http://docs.oracle.com/javaee/7/api/javax/xml/ws/WebServiceFeature.html) as last input parameter.

To test the rule, there are 2 classes:

- `HelloWorldImplService` already has the right method with `WebServiceFeature` parameter and so this class should not fire the rule
- `RestaurantServiceATService` is missing the method with `WebServiceFeature` parameter so only this test class should fire the rule (that's why there's `<iterable-filter size="1">` in `jax-ws-00000-test` test from `jax-ws.windup.test.xml` file)

The rule doesn't pass the test because it never fires **BUT** if you comment/remove in `HelloWorldImplService` the "right" constructor:
```java
    public HelloWorldImplService(URL wsdlLocation, QName serviceName, WebServiceFeature... features) {
        super(wsdlLocation, serviceName, features);
    }
```
then the rule fires twice, one per each test file.