### PR TITLE
prepare for next release

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 
     <groupId>org.jboss.windup.rules</groupId>
     <artifactId>windup-rulesets</artifactId>
-    <version>4.1.0-SNAPSHOT</version>
+    <version>4.0.1-SNAPSHOT</version>
 
     <name>Windup Rulesets</name>
 

--- a/pom.xml
+++ b/pom.xml
@@ -23,7 +23,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <version.windup>4.1.0-SNAPSHOT</version.windup>
+        <version.windup>4.0.1-SNAPSHOT</version.windup>
     </properties>
 
     <scm>


### PR DESCRIPTION
Changed artifact version from `4.1.0-SNAPSHOT` to `4.0.1-SNAPSHOT`.
Done using `mvn --batch-mode release:update-versions -DdevelopmentVersion=4.0.1-SNAPSHOT` command from the [maven-release-plugin](http://maven.apache.org/maven-release/maven-release-plugin/examples/update-versions.html#)
The `release-pom.xml` file was already deleted in https://github.com/windup/windup-rulesets/commit/37ac79623db3f7515c9e14b7f771a01718a69178
