### PR TITLE
WINDUPRULE-335 Jboss security configuration descriptor

### DIFF
--- a/rules-reviewed/eap7/eap5/jboss-eap5-7-xml.windup.xml
+++ b/rules-reviewed/eap7/eap5/jboss-eap5-7-xml.windup.xml
@@ -124,15 +124,13 @@
                 <xmlfile matches="//*[local-name()='policy']" in="login-config.xml"/>
             </when>
             <perform>
-                <classification issue-display-mode="detail-only" title="JBoss security configuration descriptor (prior to AS 7 / EAP 6)" effort="0">
-                    <link title="JBoss Login Modules" href="http://docs.jboss.org/jbosssecurity/docs/6.0/security_guide/html/Login_Modules.html"/>
-                    <tag>security</tag>
-                </classification>
+                <classification issue-display-mode="detail-only" title="JBoss security configuration descriptor (login-config.xml)" effort="0" />
                 <hint title="JBoss security configuration descriptor (login-config.xml)" effort="5" category-id="mandatory">
                     <message>Before JBoss EAP 6, authentication security domains and login modules could be configured in a `login-config.xml` file.
                     JBoss EAP 6+ does not support the `login-config.xml` descriptor. Security is now configured inside the server configuration. Please refer to the corresponding server security guide.
                     </message>
                     <link title="JBoss EAP 7 - How To Configure Server Security" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.1/html-single/how_to_configure_server_security/"/>
+                    <link title="JBoss Login Modules" href="http://docs.jboss.org/jbosssecurity/docs/6.0/security_guide/html/Login_Modules.html"/>
                     <tag>security</tag>
                     <tag>jboss-eap5</tag>
                 </hint>


### PR DESCRIPTION
- classification's title has been changed consistently w/ the hint's title
- let tags only for hint to avoid duplication
- moved the link from the classification the the hint to have them all in the same place