### PR TITLE
WINDUPRULE-339 jboss-beans.xml not detected

### DIFF
--- a/rules-reviewed/eap7/eap4and5/jboss-eap4and5to6and7-xml.windup.xml
+++ b/rules-reviewed/eap7/eap4and5/jboss-eap4and5to6and7-xml.windup.xml
@@ -38,12 +38,12 @@
                 </hint>
             </perform>
             <where param="types">
-                <matches pattern="(service|bean)" />
+                <matches pattern="(service|beans)" />
             </where>
         </rule>
         <rule id="jboss-eap4and5to6and7-xml-02000">
             <when>
-                <xmlfile matches="//mbean[@code='org.jboss.system.BarrierController']" in="jboss-{types}.xml" />
+                <xmlfile matches="//mbean[@code='org.jboss.system.BarrierController']" in="jboss-service.xml" />
             </when>
             <perform>
                 <hint issue-display-mode="all" title="Replace BarrierController service" effort="1" category-id="mandatory">
@@ -59,13 +59,13 @@
                     <link title="JBoss EAP 6 - Migration Guide" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/#Review_The_List_of_Deprecated_and_Unsupported_Features"/>
                 </hint>
             </perform>
-            <where param="types">
-                <matches pattern="(service|bean)" />
-            </where>
         </rule>
         <rule id="jboss-eap4and5to6and7-xml-03000">
             <when>
-                <xmlfile matches="//mbean[@code='org.jboss.remoting.transport.Connector']//attribute[text()='org.jboss.remoting.marshal.compress.CompressingMarshaller' and @name='marshaller']" in="jboss-{types}.xml" />
+                <or>
+                    <xmlfile matches="//mbean[@code='org.jboss.remoting.transport.Connector']//attribute[text()='org.jboss.remoting.marshal.compress.CompressingMarshaller' and @name='marshaller']" in="jboss-service.xml" />
+                    <xmlfile matches="//value[text()='org.jboss.remoting.marshal.compress.CompressingMarshaller']" in="jboss-beans.xml"/>
+                </or>
             </when>
             <perform>
                 <hint issue-display-mode="all" title="Replace CompressingMarshaller marshaller" effort="1" category-id="mandatory">
@@ -78,9 +78,6 @@
                     <link title="How to compress remote EJB communication in JBoss EAP 6" href="https://access.redhat.com/solutions/322953"/>
                 </hint>
             </perform>
-            <where param="types">
-                <matches pattern="(service|bean)" />
-            </where>
         </rule>
         <rule id="jboss-eap4and5to6and7-xml-04000">
             <when>
@@ -123,7 +120,7 @@
         </rule>
         <rule id="jboss-eap4and5to6and7-xml-06000">
             <when>
-                <xmlfile matches="//mbean[@code='org.jboss.naming.NamingAlias']" in="jboss-{types}.xml"/>
+                <xmlfile matches="//mbean[@code='org.jboss.naming.NamingAlias']" in="jboss-service.xml"/>
             </when>
             <perform>
                 <iteration>
@@ -134,17 +131,15 @@
                         The class your `jboss-{types}.xml` file is trying to instantiate (`org.jboss.naming.NamingAlias`) was an implementation detail of JBoss EAP 5's naming components that does not exist in JBoss EAP 6.
                         ]]>
                     </message>
+                    <link title="JBoss EAP 5 - The org.jboss.naming.NamingAlias MBean" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/#Additional_Naming_MBeans-The_org.jboss.naming.NamingAlias_MBean"/>
                     <link title="NamingAlias ClassNotFoundException when migrating SAR to JBoss EAP 6" href="https://access.redhat.com/solutions/314303"/>
                 </hint>
                 </iteration>
             </perform>
-            <where param="types">
-                <matches pattern="(service|bean)" />
-            </where>
         </rule>
         <rule id="jboss-eap4and5to6and7-xml-07000">
             <when>
-                <xmlfile matches="//mbean[@code='org.jboss.security.plugins.JaasSecurityManagerService']/attribute[@name='DefaultCacheTimeout']" in="jboss-{types}.xml"/>
+                <xmlfile matches="//mbean[@code='org.jboss.security.plugins.JaasSecurityManagerService']/attribute[@name='DefaultCacheTimeout']" in="jboss-service.xml"/>
             </when>
             <perform>
                 <hint issue-display-mode="all" title="Set authentication cache timeout " effort="1" category-id="mandatory">
@@ -153,12 +148,10 @@
                         In JBoss EAP 6 and 7 you can set the JAAS cache timeout, changing the `cache-type` to `infinispan` which uses Infinispan cache which has an expiration capability.
                         ]]>
                     </message>
+                    <link title="JBoss EAP 5 - Custom Callback Handlers" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/security_guide/#Custom_Callback_Handlers"/>
                     <link title="How to set authentication cache timeout in JBoss EAP6/7" href="https://access.redhat.com/solutions/259693"/>
                 </hint>
             </perform>
-            <where param="types">
-                <matches pattern="(service|bean)" />
-            </where>
         </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/eap7/eap4and5/tests/data/xml/jboss-beans.xml
+++ b/rules-reviewed/eap7/eap4and5/tests/data/xml/jboss-beans.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<deployment>
+    <bean name="JBMConnector" class="org.jboss.remoting.transport.Connector">
+        <annotation>@org.jboss.aop.microcontainer.aspects.jmx.JMX
+            (name="jboss.messaging:service=Connector,transport=bisocket",
+            exposedInterface=org.jboss.remoting.transport.ConnectorMBean.class,
+            registerDirectly=true)
+        </annotation>
+        <property name="serverConfiguration"><inject bean="JBMConfiguration"/></property>
+    </bean>
+    <!-- Remoting server configuration -->
+    <bean name="JBMConfiguration" class="org.jboss.remoting.ServerConfiguration">
+        <constructor>
+            <parameter>bisocket</parameter>
+        </constructor>
+        <!-- Parameters visible to both client and server -->
+        <property name="invokerLocatorParameters">
+            <map keyClass="java.lang.String" valueClass="java.lang.String">
+                <entry>
+                    <key>serverBindAddress</key>
+                    <value>
+                        <value-factory bean="ServiceBindingManager" method="getStringBinding">
+                            <parameter>JBMConnector</parameter>
+                            <parameter>${host}</parameter>
+                        </value-factory>
+                    </value>
+                </entry>
+                <entry>
+                    <key>serverBindPort</key>
+                    <value>
+                        <value-factory bean="ServiceBindingManager" method="getStringBinding">
+                            <parameter>JBMConnector</parameter>
+                            <parameter>${port}</parameter>
+                        </value-factory>
+                    </value>
+                </entry>
+                <entry>
+                    <key>marshaller</key>
+                    <value>org.jboss.remoting.marshal.compress.CompressingMarshaller</value>
+                </entry>
+                <entry>
+                    <key>unmarshaller</key>
+                    <value>org.jboss.remoting.marshal.compress.CompressingUnMarshaller</value>
+                </entry>
+            </map>
+        </property>
+        <!-- Parameters visible only to server -->
+        <property name="serverParameters">
+            <map keyClass="java.lang.String" valueClass="java.lang.String">
+                <entry><key>callbackTimeout</key> <value>10000</value></entry>
+            </map>
+        </property>
+    </bean>
+</deployment>

--- a/rules-reviewed/eap7/eap4and5/tests/jboss-eap4and5to6and7-xml.windup.test.xml
+++ b/rules-reviewed/eap7/eap4and5/tests/jboss-eap4and5to6and7-xml.windup.test.xml
@@ -7,7 +7,7 @@
             <rule id="jboss-eap4and5to6and7-xml-01000-test">
                 <when>
                     <not>
-                        <iterable-filter size="1">
+                        <iterable-filter size="2">
                             <hint-exists message="MBeans were part of the core architecture in previous versions of Red Hat JBoss Enterprise Application Platform"/>
                         </iterable-filter>
                     </not>
@@ -31,7 +31,7 @@
             <rule id="jboss-eap4and5to6and7-xml-03000-test">
                 <when>
                     <not>
-                        <iterable-filter size="1">
+                        <iterable-filter size="2">
                             <hint-exists message="`CompressingMarshaller` marshaller is no longer available in JBoss EAP 6"/>
                         </iterable-filter>
                     </not>


### PR DESCRIPTION
- fixed typo `beans` in `<where>` parameter for `jboss-beans.xml` file name
- rule `jboss-eap4and5to6and7-xml-02000` search only for MBean since it's the only way to define  the`BarrierController` service
- rule `jboss-eap4and5to6and7-xml-03000` searches w/ different patterns based on the file type
- rule `jboss-eap4and5to6and7-xml-06000` searches only for MBean since it's the only way to define  the `NamingAlias` service as documented in the link to the official documentation added to the `<hint>`
- rule `jboss-eap4and5to6and7-xml-07000` searches only for MBean since it's the only way to define  the `JaasSecurityManagerService` service as documented in the link to the official documentation added to the `<hint>`
- added `jboss-beans.xml` test file and accordingly changed the expected results for the tests