### PR TITLE
WINDUP-1982 Fixed test file pattern

### DIFF
--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
@@ -114,7 +114,7 @@ public class WindupRulesTest
         final List<String> successes = new ArrayList<>();
         final Map<String, Exception> errors = new LinkedHashMap<>();
 
-        FileSuffixPredicate predicate = new FileSuffixPredicate("\\.windup\\.test\\.xml");
+        FileSuffixPredicate predicate = new FileSuffixPredicate("\\.(windup|rhamt)\\.test\\.xml");
         final File directory = new File("rules");
         final File rulesReviewed = new File("rules-reviewed");
         Visitor<File> mainVisitor = new RuleTestVisitor(successes, errors, directory);


### PR DESCRIPTION
Fix to have the `*.rhamt.test.xml` files to work.