### PR TITLE
WINDUPRULE-152 issue with hsearch-00116 conditions

### DIFF
--- a/rules-reviewed/eap7/eap6/hsearch.windup.groovy
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.groovy
@@ -1,0 +1,75 @@
+import org.jboss.windup.config.GraphRewrite
+import org.jboss.windup.config.parameters.ParameterizedIterationOperation
+import org.jboss.windup.config.metadata.TechnologyReference
+import org.ocpsoft.rewrite.context.EvaluationContext
+import org.ocpsoft.rewrite.param.ParameterStore
+
+import org.jboss.windup.ast.java.data.TypeReferenceLocation
+import org.jboss.windup.reporting.config.Hint
+import org.jboss.windup.reporting.config.Link
+import org.jboss.windup.rules.apps.java.condition.JavaClass
+import org.jboss.windup.rules.apps.java.scan.ast.annotations.JavaAnnotationTypeReferenceModel
+import org.jboss.windup.rules.apps.java.scan.ast.annotations.JavaAnnotationTypeValueModel
+import org.jboss.windup.reporting.category.IssueCategoryRegistry
+import org.jboss.windup.reporting.category.IssueCategory
+import org.jboss.windup.reporting.xml.HintHandler
+
+import org.jboss.windup.util.Logging
+
+ruleSet("hsearch-groovy")
+        .addSourceTechnology(new TechnologyReference("hibernate", "[4,)"))
+        .addSourceTechnology(new TechnologyReference("eap", "[6,7)"))
+        .addTargetTechnology(new TechnologyReference("hibernate", "[5,)"))
+        .addTargetTechnology(new TechnologyReference("eap", "[7,8)"))
+        .addRule()
+        .when(
+            JavaClass.references("org.hibernate.search.annotations.{bridge}").at(TypeReferenceLocation.ANNOTATION)
+        )
+        .perform(
+        new ParameterizedIterationOperation<JavaAnnotationTypeReferenceModel> () {
+            Hint hint = Hint
+                    .titled("Hibernate Search 5 - Changes in indexing date values")
+                    .withText(HintHandler.trimLeadingAndTrailingSpaces(
+                    "Date and Calendar values are no longer indexed as strings. Instead, instances are encoded as long values representing the number\n" +
+                    "of milliseconds since January 1, 1970, 00:00:00 GMT. You can switch the indexing format by using the new EncodingType enum. For example:\n" +
+                    "\n" +
+                    "```java\n" +
+                    "@DateBridge(encoding=EncodingType.STRING)\n" +
+                    "@CalendarBridge(encoding=EncodingType.STRING)\n" +
+                    "```\n" +
+                    "\n" +
+                    "The encoding change for dates is important and can have a big impact on application behavior. If you have\n" +
+                    "a query that targets a field that was previously string-encoded, but is now encoded numerically, you must update the query. \n" +
+                    "You must also make sure that all fields targeted by faceting are string encoded.\n" +
+                    "If you use the Search query DSL, the correct query should be created automatically for you.\n"))
+                    .with(Link.to("Number and Date Index Formatting Changes in Hibernate Search 5.x", "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_hibernate_search_number_and_date_index_formatting_changes"))
+                    .with(Link.to("Number and date index format", "http://hibernate.org/search/documentation/migrate/5.0/#number-and-date-index-format"))
+                    .with(Link.to("Javadoc API for org.hibernate.search.bridge.builtin package", "http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/bridge/builtin/package-summary.html"))
+                    .with(Link.to("Javadoc API for IntegerBridge", "http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/bridge/builtin/IntegerBridge.html"))
+                    .withTags(new HashSet<>(Arrays.asList("hibernate-search")))
+                    .withEffort(1);
+
+            public Set<String> getRequiredParameterNames() {
+                return hint.getRequiredParameterNames();
+            }
+
+            public void setParameterStore(ParameterStore store) {
+                hint.setParameterStore(store);
+            }
+
+            public void performParameterized(final GraphRewrite event, final EvaluationContext context, final JavaAnnotationTypeReferenceModel locationModel) {
+                boolean hasEncodingElement = false;
+                    Map<String, JavaAnnotationTypeValueModel> annotationValues = locationModel.getAnnotationValues();
+                    if (annotationValues != null && annotationValues.containsKey("encoding")) {
+                        hasEncodingElement = true;
+                    }
+                if (!hasEncodingElement) {
+                    IssueCategoryRegistry issueCategoryRegistry = IssueCategoryRegistry.instance(context)
+                    IssueCategory issueCategory = issueCategoryRegistry.getByID("optional")
+                    hint.withIssueCategory(issueCategory).perform(event, context)
+                }
+            }
+        }
+        )
+        .where("bridge").matches("DateBridge|CalendarBridge")
+        .withId("hsearch-groovy-01000")

--- a/rules-reviewed/eap7/eap6/hsearch.windup.groovy
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.groovy
@@ -46,7 +46,7 @@ If you use the Search query DSL, the correct query should be created automatical
                     .with(Link.to("Number and date index format", "http://hibernate.org/search/documentation/migrate/5.0/#number-and-date-index-format"))
                     .with(Link.to("Javadoc API for org.hibernate.search.bridge.builtin package", "http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/bridge/builtin/package-summary.html"))
                     .withTags(new HashSet<>(Arrays.asList("hibernate-search")))
-                    .withEffort(1);
+                    .withEffort(0);
 
             public Set<String> getRequiredParameterNames() {
                 return hint.getRequiredParameterNames();
@@ -64,7 +64,7 @@ If you use the Search query DSL, the correct query should be created automatical
                     }
                 if (!hasEncodingElement) {
                     IssueCategoryRegistry issueCategoryRegistry = IssueCategoryRegistry.instance(context)
-                    IssueCategory issueCategory = issueCategoryRegistry.getByID("optional")
+                    IssueCategory issueCategory = issueCategoryRegistry.getByID("potential")
                     hint.withIssueCategory(issueCategory).perform(event, context)
                 }
             }

--- a/rules-reviewed/eap7/eap6/hsearch.windup.groovy
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.groovy
@@ -29,23 +29,22 @@ ruleSet("hsearch-groovy")
         new ParameterizedIterationOperation<JavaAnnotationTypeReferenceModel> () {
             Hint hint = Hint
                     .titled("Hibernate Search 5 - Changes in indexing date values")
-                    .withText(HintHandler.trimLeadingAndTrailingSpaces(
-                    "Date and Calendar values are no longer indexed as strings. Instead, instances are encoded as long values representing the number\n" +
-                    "of milliseconds since January 1, 1970, 00:00:00 GMT. You can switch the indexing format by using the new EncodingType enum. For example:\n" +
-                    "\n" +
-                    "```java\n" +
-                    "@DateBridge(encoding=EncodingType.STRING)\n" +
-                    "@CalendarBridge(encoding=EncodingType.STRING)\n" +
-                    "```\n" +
-                    "\n" +
-                    "The encoding change for dates is important and can have a big impact on application behavior. If you have\n" +
-                    "a query that targets a field that was previously string-encoded, but is now encoded numerically, you must update the query. \n" +
-                    "You must also make sure that all fields targeted by faceting are string encoded.\n" +
-                    "If you use the Search query DSL, the correct query should be created automatically for you.\n"))
+                    .withText(
+                    """Date and Calendar values are no longer indexed as strings. Instead, instances are encoded as long values representing the number
+of milliseconds since January 1, 1970, 00:00:00 GMT. You can switch the indexing format by using the new EncodingType enum. For example:
+
+```java
+@DateBridge(encoding=EncodingType.STRING)
+@CalendarBridge(encoding=EncodingType.STRING)
+```
+
+The encoding change for dates is important and can have a big impact on application behavior. If you have
+a query that targets a field that was previously string-encoded, but is now encoded numerically, you must update the query.
+You must also make sure that all fields targeted by faceting are string encoded.
+If you use the Search query DSL, the correct query should be created automatically for you.""")
                     .with(Link.to("Number and Date Index Formatting Changes in Hibernate Search 5.x", "https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_hibernate_search_number_and_date_index_formatting_changes"))
                     .with(Link.to("Number and date index format", "http://hibernate.org/search/documentation/migrate/5.0/#number-and-date-index-format"))
                     .with(Link.to("Javadoc API for org.hibernate.search.bridge.builtin package", "http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/bridge/builtin/package-summary.html"))
-                    .with(Link.to("Javadoc API for IntegerBridge", "http://docs.jboss.org/hibernate/search/5.5/api/org/hibernate/search/bridge/builtin/IntegerBridge.html"))
                     .withTags(new HashSet<>(Arrays.asList("hibernate-search")))
                     .withEffort(1);
 

--- a/rules-reviewed/eap7/eap6/hsearch.windup.xml
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.xml
@@ -482,9 +482,6 @@
                         <annotation-literal name="index" pattern="Index.YES"/>
                         <annotation-type pattern="org.hibernate.search.annotations.NumericField"/>
                     </javaclass>
-                    <javaclass references="org.hibernate.search.annotations.{bridge}">
-                        <location>ANNOTATION</location>
-                    </javaclass>
                     <javaclass references="java.util.{date}">
                         <annotation-type pattern="org.hibernate.search.annotations.Field" />
                         <annotation-type pattern="org.hibernate.search.annotations.Fields"/>
@@ -532,9 +529,6 @@
             </where>
             <where param="date">
                 <matches pattern="(Calendar|Date)" />
-            </where>
-            <where param="bridge">
-                <matches pattern="(DateBridge|CalendarBridge)"/>
             </where>
         </rule>
         <!-- When using @Field(indexNullAs=) to encode a null marker value in the index, -->

--- a/rules-reviewed/eap7/eap6/tests/data/data-hsearch/Book.java
+++ b/rules-reviewed/eap7/eap6/tests/data/data-hsearch/Book.java
@@ -16,6 +16,7 @@ import org.hibernate.search.annotations.AnalyzerDef;
 import org.hibernate.search.annotations.DateBridge;
 import org.hibernate.search.annotations.CalendarBridge;
 import org.hibernate.search.annotations.DocumentId;
+import org.hibernate.search.annotations.EncodingType;
 import org.hibernate.search.annotations.Field;
 import org.hibernate.search.annotations.Indexed;
 import org.hibernate.search.annotations.IndexedEmbedded;
@@ -144,6 +145,30 @@ public class Book
     
     @CalendarBridge(resolution = Resolution.DAY)
     public Calendar getCalendarPublication() 
+    {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(this.publicationDate);
+        return cal;
+    }
+
+    @CalendarBridge(resolution = Resolution.DAY, encoding = EncodingType.NUMERIC)
+    public Calendar getEncodedCalendarPublication()
+    {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(this.publicationDate);
+        return cal;
+    }
+
+    @DateBridge(encoding = EncodingType.STRING, resolution = Resolution.MILLISECOND)
+    public Calendar getEncodedDatePublication()
+    {
+        Calendar cal = Calendar.getInstance();
+        cal.setTime(this.publicationDate);
+        return cal;
+    }
+
+    @DateBridge(resolution = Resolution.MILLISECOND)
+    public Calendar getDatePublication()
     {
         Calendar cal = Calendar.getInstance();
         cal.setTime(this.publicationDate);

--- a/rules-reviewed/eap7/eap6/tests/hsearch.windup.test.xml
+++ b/rules-reviewed/eap7/eap6/tests/hsearch.windup.test.xml
@@ -271,7 +271,7 @@
             <rule id="hsearch-00116-test">
                 <when>
                     <not>
-                        <iterable-filter size="2">
+                        <iterable-filter size="1">
                             <hint-exists message="Numbers and dates are now indexed as numeric fields by default.*"/>
                         </iterable-filter>
                     </not>
@@ -609,7 +609,19 @@
                 <perform>
                     <fail message="hsearch-00240 hint not found!" />
                 </perform>
-            </rule>            
+            </rule>
+            <rule id="hsearch-groovy-01000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="Date and Calendar values are no longer indexed as strings*" />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="hsearch-groovy-01000 hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
The new rules searches for `DateBridge` and `CalendarBridge` annotations without the `encoding` attribute