### PR TITLE
WIP WINDUP-2000 Create Validation report

### DIFF
--- a/src/test/java/org/jboss/windup/rules/tests/ParameterizedArquillianRunner.java
+++ b/src/test/java/org/jboss/windup/rules/tests/ParameterizedArquillianRunner.java
@@ -1,0 +1,66 @@
+package org.jboss.windup.rules.tests;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.jboss.arquillian.junit.Arquillian;
+import org.junit.runner.Description;
+import org.junit.runners.Parameterized;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.InitializationError;
+
+public class ParameterizedArquillianRunner extends Arquillian {
+
+    private final Collection<Object> parameters;
+
+    private final String name;
+    
+    public ParameterizedArquillianRunner(Class<?> testClass) throws InitializationError, InvocationTargetException, IllegalAccessException {
+        super(testClass);
+        Collection<Object> result = null;
+        for (Method method : testClass.getMethods()) {
+            if (method.isAnnotationPresent(Parameterized.Parameters.class) &&
+                    Modifier.isStatic(method.getModifiers()) &&
+                    Modifier.isPublic(method.getModifiers()))
+            {
+                 result =  (Collection<Object>)method.invoke(testClass, null);
+                 break;
+            }
+        }
+        if (result != null)
+        {
+            parameters = result;
+        } else
+        {
+            parameters = new ArrayList<>();
+        }
+        name = testClass.getName();
+    }
+
+    @Override
+    protected List<FrameworkMethod> getChildren() {
+        // scan test class for methods annotated with @Test
+        List<FrameworkMethod> superMethods = super.getChildren();
+        List<FrameworkMethod> toReturn = new ArrayList<>(parameters.size() * superMethods.size());
+        superMethods.forEach(frameworkMethod -> parameters.forEach(o -> toReturn.add(new WindupFrameworkMethod(frameworkMethod.getMethod(), ((File[])o)[0].toString()))));
+        return toReturn;
+    }
+
+    @Override
+    protected Description describeChild(FrameworkMethod method) {
+        // create Description based on method name
+        if (method instanceof WindupFrameworkMethod)
+        {
+            return Description.createTestDescription(getTestClass().getJavaClass(),
+                    method.getName(), method.getAnnotations());
+        } else
+        {
+            return super.describeChild(method);
+        }
+    }
+}

--- a/src/test/java/org/jboss/windup/rules/tests/RulesPath.java
+++ b/src/test/java/org/jboss/windup/rules/tests/RulesPath.java
@@ -1,0 +1,29 @@
+package org.jboss.windup.rules.tests;
+
+import javax.inject.Singleton;
+import java.io.File;
+import java.util.Collection;
+import java.util.Iterator;
+
+@Singleton
+public class RulesPath {
+
+    private Iterator<File[]> iterator;
+
+    public void setRules(Collection<File[]> rules)
+    {
+        if (this.iterator == null)
+        {
+            this.iterator = rules.iterator();
+        }
+    }
+
+    public File[] getNextRule()
+    {
+        if (iterator.hasNext())
+        {
+            return iterator.next();
+        }
+        return null;
+    }
+}

--- a/src/test/java/org/jboss/windup/rules/tests/WindupFrameworkMethod.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupFrameworkMethod.java
@@ -1,0 +1,20 @@
+package org.jboss.windup.rules.tests;
+
+import org.junit.runners.model.FrameworkMethod;
+
+import java.lang.reflect.Method;
+
+public class WindupFrameworkMethod extends FrameworkMethod {
+    
+    private final String ruleToTest;
+
+    public WindupFrameworkMethod(Method method, String ruleToTest) {
+        super(method);
+        this.ruleToTest = ruleToTest;
+    }
+
+    @Override
+    public String getName() {
+        return String.format("%s with %s", super.getName(), ruleToTest);
+    }
+}

--- a/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
+++ b/src/test/java/org/jboss/windup/rules/tests/WindupRulesMultipleTests.java
@@ -1,0 +1,272 @@
+package org.jboss.windup.rules.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import javax.inject.Inject;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.forge.arquillian.AddonDependencies;
+import org.jboss.forge.arquillian.AddonDependency;
+import org.jboss.forge.arquillian.archive.AddonArchive;
+import org.jboss.forge.furnace.Furnace;
+import org.jboss.forge.furnace.util.Predicate;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.windup.config.DefaultEvaluationContext;
+import org.jboss.windup.config.GraphRewrite;
+import org.jboss.windup.config.RuleProvider;
+import org.jboss.windup.config.RuleSubset;
+import org.jboss.windup.config.loader.RuleLoaderContext;
+import org.jboss.windup.config.metadata.RuleMetadataType;
+import org.jboss.windup.config.parser.ParserContext;
+import org.jboss.windup.exec.WindupProcessor;
+import org.jboss.windup.exec.configuration.WindupConfiguration;
+import org.jboss.windup.exec.configuration.options.SourceOption;
+import org.jboss.windup.exec.configuration.options.TargetOption;
+import org.jboss.windup.graph.GraphContext;
+import org.jboss.windup.graph.GraphContextFactory;
+import org.jboss.windup.graph.model.ProjectModel;
+import org.jboss.windup.graph.model.resource.FileModel;
+import org.jboss.windup.rules.apps.java.config.SourceModeOption;
+import org.jboss.windup.util.file.FileSuffixPredicate;
+import org.jboss.windup.util.file.FileVisit;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.ocpsoft.logging.Logger;
+import org.ocpsoft.rewrite.config.Configuration;
+import org.ocpsoft.rewrite.config.Rule;
+import org.ocpsoft.rewrite.context.Context;
+import org.ocpsoft.rewrite.param.DefaultParameterValueStore;
+import org.ocpsoft.rewrite.param.ParameterValueStore;
+
+@RunWith(ParameterizedArquillianRunner.class)
+public class WindupRulesMultipleTests {
+
+    private static final Logger LOG = Logger.getLogger(WindupRulesMultipleTests.class);
+
+    private static String RUN_TEST_MATCHING = "runTestsMatching";
+    
+    @Parameterized.Parameters(name = "{index}: Test {0}")
+    public static Collection<File[]> data()
+    {
+        String testToExecute = System.getProperty(RUN_TEST_MATCHING);
+        if (StringUtils.isBlank(testToExecute))
+        {
+            testToExecute = "";
+        }
+        Pattern testToExecutePattern = Pattern.compile(testToExecute);
+        FileSuffixPredicate predicate = new FileSuffixPredicate("\\.(windup|rhamt)\\.test\\.xml");
+        final File directory = new File("rules");
+        final File rulesReviewed = new File("rules-reviewed");
+        final List<File[]> rulesetToTest = new ArrayList<>();
+        FileVisit.visit(directory, predicate).stream()
+                    .filter(file -> testToExecutePattern.matcher(file.toString()).find()).map(file -> new File[] { file, directory })
+                    .forEach(files -> rulesetToTest.add(files));
+        FileVisit.visit(rulesReviewed, predicate).stream()
+                    .filter(file -> testToExecutePattern.matcher(file.toString()).find())
+                    .map(file -> new File[] { file, rulesReviewed }).forEach(files -> rulesetToTest.add(files));
+        return rulesetToTest;
+    }
+
+    @Deployment
+    @AddonDependencies({
+            @AddonDependency(name = "org.jboss.windup.exec:windup-exec"),
+            @AddonDependency(name = "org.jboss.windup.config:windup-config-xml"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java-ee"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-java-project"),
+            @AddonDependency(name = "org.jboss.windup.rules.apps:windup-rules-xml"),
+            @AddonDependency(name = "org.jboss.windup.reporting:windup-reporting"),
+            @AddonDependency(name = "org.jboss.windup.utils:windup-utils"),
+            @AddonDependency(name = "org.jboss.forge.furnace.container:cdi")
+    })
+    public static AddonArchive getDeployment()
+    {
+        return ShrinkWrap.create(AddonArchive.class)
+                .addBeansXML()
+                .addPackage(WindupRulesMultipleTests.class.getPackage());
+    }
+
+    @Inject
+    private Furnace furnace;
+
+    @Inject
+    private GraphContextFactory factory;
+
+    @Inject
+    private WindupProcessor processor;
+    
+    @Inject
+    private RulesPath rulesPath;
+    
+    @Before
+    public void before()
+    {
+        rulesPath.setRules(data());
+    }
+
+    @Test
+    public void testRule()
+    {
+        File[] files = rulesPath.getNextRule();
+        LOG.info(String.format("Testing rule %s%n", files[0].getName()));
+        visit(files[0], files[1]);
+    }
+
+    public void visit(File ruleTestFile, File directory)
+    {
+        final RuleLoaderContext ruleLoaderContext = new RuleLoaderContext();
+        final ParserContext parser = new ParserContext(furnace, ruleLoaderContext);
+
+        LOG.info("\n==============================================================================================="
+                + "\n Running test ruleset: " + ruleTestFile.getPath()
+                + "\n==============================================================================================="
+                + "\n");
+
+        try
+        {
+            Map<String, Exception> exceptions;
+            Path outputPath = getDefaultPath();
+            try (GraphContext context = factory.create(outputPath, true))
+            {
+                // load the ruletest file
+                RuleTest ruleTest = parser.processDocument(ruleTestFile.toURI());
+                List<Path> rulePaths = new ArrayList<>();
+                if (ruleTest.getRulePaths().isEmpty())
+                {
+                    // The default path is ../, so this is two directories up from the test file iteself.
+                    rulePaths.add(ruleTestFile.getParentFile().getParentFile().toPath().normalize().toAbsolutePath());
+                }
+                else
+                {
+                    for (String rulePath : ruleTest.getRulePaths())
+                    {
+                        Path ruleTestDirectory = ruleTestFile.toPath().getParent().normalize();
+                        Path path = ruleTestDirectory.resolve(rulePath).normalize().toAbsolutePath();
+                        rulePaths.add(path.toAbsolutePath());
+                    }
+                }
+
+                Configuration ruleTestConfiguration = parser.getBuilder().getConfiguration(ruleLoaderContext);
+
+/*                String idsToExecute = System.getProperty(RUN_TEST_ID_MATCHING);
+                if(idsToExecute != null) {
+                    ConfigurationBuilder newConfiguration = ConfigurationBuilder.begin();
+                    for (Rule rule : ruleTestConfiguration.getRules())
+                    {
+                        if(rule.getId().matches(idsToExecute)) {
+                            newConfiguration.addRule(rule);
+                        }
+                    }
+                    ruleTestConfiguration = newConfiguration;
+                }*/
+                for (Rule rule : ruleTestConfiguration.getRules())
+                {
+                    parser.getBuilder().enhanceRuleMetadata(parser.getBuilder(), rule);
+                    if (rule instanceof Context)
+                    {
+                        ((Context) rule).put(RuleMetadataType.HALT_ON_EXCEPTION, false);
+                    }
+                }
+
+                // run windup
+                File testDataPath = new File(ruleTestFile.getParentFile(), ruleTest.getTestDataPath());
+                Path reportPath = outputPath.resolve("reports");
+                runWindup(context, directory, rulePaths, testDataPath, reportPath.toFile(), ruleTest.isSourceMode(), ruleTest.getSource(), ruleTest.getTarget());
+
+                // run the assertions from the ruletest file
+                GraphRewrite event = new GraphRewrite(context);
+                RuleSubset ruleSubset = RuleSubset.create(ruleTestConfiguration);
+                ruleSubset.perform(event, createEvalContext(event));
+                exceptions = ruleSubset.getExceptions();
+            }
+            if (exceptions != null && exceptions.isEmpty())
+            {
+                //successes.add(ruleTestFile.toString());
+            } else
+            {
+                // here are added all failed tests instead of failed test files
+                Assert.fail(exceptions.toString());
+            }
+        }
+        catch (Exception e)
+        {
+            e.printStackTrace();
+        }
+    }
+
+    private DefaultEvaluationContext createEvalContext(GraphRewrite event)
+    {
+        final DefaultEvaluationContext evaluationContext = new DefaultEvaluationContext();
+        final DefaultParameterValueStore values = new DefaultParameterValueStore();
+        evaluationContext.put(ParameterValueStore.class, values);
+        return evaluationContext;
+    }
+
+    private Path getDefaultPath()
+    {
+        return FileUtils.getTempDirectory().toPath().resolve("WindupRulesTests").resolve("windupgraph_" + RandomStringUtils.randomAlphanumeric(6));
+    }
+
+    private void runWindup(GraphContext context, File baseRuleDirectory, final List<Path> rulePaths, File input, File output, boolean sourceMode, String source, String target) throws IOException
+    {
+        ProjectModel pm = context.getFramed().addFramedVertex(ProjectModel.class);
+        pm.setName("Project: " + input.getAbsolutePath());
+        FileModel inputPath = context.getFramed().addFramedVertex(FileModel.class);
+        inputPath.setFilePath(input.getCanonicalPath());
+
+        FileUtils.deleteDirectory(output);
+        Files.createDirectories(output.toPath());
+
+        pm.setRootFileModel(inputPath);
+        WindupConfiguration windupConfiguration = new WindupConfiguration()
+                .setGraphContext(context);
+        windupConfiguration.addInputPath(Paths.get(inputPath.getFilePath()));
+        windupConfiguration.setOutputDirectory(output.toPath());
+        windupConfiguration.addDefaultUserRulesDirectory(baseRuleDirectory.toPath());
+        windupConfiguration.setOptionValue(SourceModeOption.NAME, sourceMode);
+        windupConfiguration.setOnline(false);
+        if (StringUtils.isNotBlank(source))
+            windupConfiguration.setOptionValue(SourceOption.NAME, Collections.singletonList(source));
+
+        if (StringUtils.isNotBlank(target))
+            windupConfiguration.setOptionValue(TargetOption.NAME, Collections.singletonList(target));
+
+        final String baseRulesPathNormalized = baseRuleDirectory.toPath().normalize().toAbsolutePath().toString();
+        windupConfiguration.setRuleProviderFilter(new Predicate<RuleProvider>()
+        {
+            @Override
+            public boolean accept(RuleProvider type)
+            {
+                if (type.getMetadata().getOrigin() == null)
+                    return true;
+
+                if (!type.getMetadata().getOrigin().contains(baseRulesPathNormalized))
+                    return true;
+
+                for (Path acceptedRulePath : rulePaths)
+                {
+                    if (type.getMetadata().getOrigin().contains(acceptedRulePath.toString()))
+                        return true;
+                }
+                return false;
+            }
+        });
+        processor.execute(windupConfiguration);
+    }
+}


### PR DESCRIPTION
This needs https://github.com/windup/windup/pull/1320

New `WindupRulesMultipleTests` test class that has just one test method but it gets executed as many times as the number of test rules found by the [`data()`](https://github.com/windup/windup-rulesets/compare/master...mrizzi:WINDUP-2000?expand=1#diff-5e70928c242f2bc815464279d075d8dcR65) method.
I used the `org.junit.runners.Parameterized.Parameters` annotation so that once Arquillian will be able to work with [JUnit Parameterized](https://github.com/junit-team/junit4/wiki/parameterized-tests) we will be compatible.
`ParameterizedArquillianRunner` class is used to create multiple tests (in [`getChildren`](https://github.com/windup/windup-rulesets/compare/master...mrizzi:WINDUP-2000?expand=1#diff-98fec262ca4da4a917075243972bc058R46) method) and change their names/labels so that they means something for us (they have the test rule file path).
The 'visit' method is taken from current [WindupRulesTest](https://github.com/windup/windup-rulesets/blob/master/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java#L162) and it has to be enhanced to support the `runTestIdMatching` property (maybe also optimized and renamed).

To use this new test and get a nice HTML report, you can use the command:
`$ mvn -Dtest=WindupRulesMultipleTests clean surefire-report:report`
or, if you want to execute only some tests:
`$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-glassfish clean surefire-report:report`
and you'll find the report in `target/site/surefire-report.html`