### PR TITLE
WINDUP-2000 Adding Sonatype snapshot repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,19 @@
         </repository>
     </distributionManagement>
 
+    <repositories>
+      <repository>
+        <id>sonatype-snapshots-repo</id>
+        <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+        <releases>
+          <enabled>false</enabled>
+        </releases>
+        <snapshots>
+          <enabled>true</enabled>
+        </snapshots>
+      </repository>
+    </repositories>
+
     <dependencyManagement>
         <dependencies>
             <dependency>


### PR DESCRIPTION
Added the Sonatype snapshot repository so that, during a new rule creation, a contributor hasn't got to clone and compile any other Windup project.