### PR TITLE
WINDUP-2266 Fix surefire report CSS and images

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -296,6 +296,26 @@
                   </includes>
                </configuration>
             </plugin>
+            <!--
+            we need to download the CSS files each time we generate the surefire report due to
+            https://issues.apache.org/jira/browse/SUREFIRE-616
+            -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-site-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>download-css</id>
+                        <goals>
+                            <goal>site</goal>
+                        </goals>
+                        <phase>test</phase>
+                    </execution>
+                </executions>
+                <configuration>
+                    <generateReports>false</generateReports>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUP-2266

To test this PR:

1. clone ruleset project
2. (optional) put demo rules to validate
3. run `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=demo clean surefire-report:report`
4. check that the report looks bad (without and style and image)
5. apply the changes from this PR
6. run the same command again and, hopefully, the report will be good