### PR TITLE
WINDUPRULE-359 - Add hint when datasource / jms have been detected

### DIFF
--- a/rules-reviewed/technology-usage/connect.windup.xml
+++ b/rules-reviewed/technology-usage/connect.windup.xml
@@ -30,6 +30,8 @@
             <perform>
                 <classification title="Embedded library - ActiveMQ" category-id="information" effort="0">
                     <description>The application embeds an ActiveMQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">ActiveMQ (embedded)</technology-tag>
             </perform>
@@ -69,6 +71,8 @@
             <perform>
                 <classification title="Embedded library - RabbitMQ Client" category-id="information" effort="0">
                     <description>The application embeds a RabbitMQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">RabbitMQ Client (embedded)</technology-tag>
             </perform>
@@ -83,6 +87,8 @@
             <perform>
                 <classification title="Embedded library - Spring Messaging Client" category-id="information" effort="0">
                     <description>The application embeds a Spring Messaging client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Spring Messaging Client (embedded)</technology-tag>
             </perform>
@@ -94,6 +100,8 @@
             <perform>
                 <classification title="Embedded library - Camel Messaging Client" category-id="information" effort="0">
                     <description>The application embeds a Camel Messaging client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Camel Messaging Client (embedded)</technology-tag>
             </perform>
@@ -105,6 +113,8 @@
             <perform>
                 <classification title="Embedded library - Amazon SQS Client" category-id="information" effort="0">
                     <description>The application embeds a Amazon SQS client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Amazon SQS Client (embedded)</technology-tag>
             </perform>
@@ -116,6 +126,8 @@
             <perform>
                 <classification title="Embedded library - HornetQ Client" category-id="information" effort="0">
                     <description>The application embeds a HornetQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">HornetQ Client (embedded)</technology-tag>
             </perform>
@@ -127,6 +139,8 @@
             <perform>
                 <classification title="Embedded library - AMQP Client" category-id="information" effort="0">
                     <description>The application embeds an AMQP client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">AMQP Client (embedded)</technology-tag>
             </perform>
@@ -138,6 +152,8 @@
             <perform>
                 <classification title="Embedded library - RocketMQ Client" category-id="information" effort="0">
                     <description>The application embeds a RocketMQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">RocketMQ Client (embedded)</technology-tag>
             </perform>
@@ -152,6 +168,8 @@
             <perform>
                 <classification title="Embedded library - 0MQ Client" category-id="information" effort="0">
                     <description>The application embeds a 0MQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">0MQ Client (embedded)</technology-tag>
             </perform>
@@ -163,6 +181,8 @@
             <perform>
                 <classification title="Embedded library - JBossMQ Client" category-id="information" effort="0">
                     <description>The application embeds a JBossMQ client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">JBossMQ Client (embedded)</technology-tag>
             </perform>
@@ -174,6 +194,8 @@
             <perform>
                 <classification title="Embedded library - Zbus Client" category-id="information" effort="0">
                     <description>The application embeds a Zbus client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Zbus Client (embedded)</technology-tag>
             </perform>
@@ -185,6 +207,8 @@
             <perform>
                 <classification title="Embedded library - Qpid Client" category-id="information" effort="0">
                     <description>The application embeds a Qpid client library.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Qpid Client (embedded)</technology-tag>
             </perform>

--- a/rules-reviewed/technology-usage/database.windup.xml
+++ b/rules-reviewed/technology-usage/database.windup.xml
@@ -19,6 +19,8 @@
             <perform>
                 <classification title="Embedded HSQLDB Driver" category-id="information" effort="0">
                     <description>The application embeds an HSQLDB driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">HSQLDB Driver</technology-tag>
             </perform>
@@ -30,6 +32,8 @@
             <perform>
                 <classification title="Embedded MySQL Driver" category-id="information" effort="0">
                     <description>The application embeds an MySQL driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">MySQL Driver</technology-tag>
             </perform>
@@ -41,6 +45,8 @@
             <perform>
                 <classification title="Embedded Derby Driver" category-id="information" effort="0">
                     <description>The application embeds an Derby driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Derby Driver</technology-tag>
             </perform>
@@ -52,6 +58,8 @@
             <perform>
                 <classification title="Embedded PostgreSQL Driver" category-id="information" effort="0">
                     <description>The application embeds an PostgreSQL driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">PostgreSQL Driver</technology-tag>
             </perform>
@@ -63,6 +71,8 @@
             <perform>
                 <classification title="Embedded H2 Driver" category-id="information" effort="0">
                     <description>The application embeds an H2 driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">H2 Driver</technology-tag>
             </perform>
@@ -77,6 +87,8 @@
             <perform>
                 <classification title="Embedded Microsoft SQL Driver" category-id="information" effort="0">
                     <description>The application embeds an Microsoft SQL driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Microsoft SQL Driver</technology-tag>
             </perform>
@@ -88,6 +100,8 @@
             <perform>
                 <classification title="Embedded SQLite Driver" category-id="information" effort="0">
                     <description>The application embeds an SQLite driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">SQLite Driver</technology-tag>
             </perform>
@@ -103,6 +117,8 @@
             <perform>
                 <classification title="Embedded Oracle DB Driver" category-id="information" effort="0">
                     <description>The application embeds an Oracle DB driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Oracle DB Driver</technology-tag>
             </perform>
@@ -124,6 +140,8 @@
             <perform>
                 <classification title="Embedded Cassandra Client" category-id="information" effort="0">
                     <description>The application embeds a Cassandra client.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Cassandra Client</technology-tag>
             </perform>
@@ -135,6 +153,8 @@
             <perform>
                 <classification title="Embedded Axion Driver" category-id="information" effort="0">
                     <description>The application embeds an Axion driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Axion Driver</technology-tag>
             </perform>
@@ -146,6 +166,8 @@
             <perform>
                 <classification title="Embedded MckoiSQLDB Driver" category-id="information" effort="0">
                     <description>The application embeds an MckoiSQLDB driver.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">MckoiSQLDB Driver</technology-tag>
             </perform>
@@ -165,6 +187,8 @@
             <perform>
                 <classification title="Embedded MongoDB Client" category-id="information" effort="0">
                     <description>The application embeds a MongoDB client.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">MongoDB Client</technology-tag>
             </perform>
@@ -183,6 +207,8 @@
                     <perform>
                         <classification title="Embedded framework - Spring Data" category-id="information" effort="0">
                             <description>The application embeds the Spring Data framework.</description>
+                            <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                            <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                         </classification>
                         <technology-tag level="INFORMATIONAL">Spring Data (embedded)</technology-tag>
                     </perform>
@@ -196,6 +222,8 @@
             <perform>
                 <classification title="Embedded framework - Morphia" category-id="information" effort="0">
                     <description>The application embeds Morphia.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Morphia</technology-tag>
             </perform>
@@ -207,6 +235,8 @@
             <perform>
                 <classification title="Embedded LevelDB Client" category-id="information" effort="0">
                     <description>The application embeds a LevelDB client.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">LevelDB Client</technology-tag>
             </perform>
@@ -218,6 +248,8 @@
             <perform>
                 <classification title="Embedded Apache HBase Client" category-id="information" effort="0">
                     <description>The application embeds an Apache HBase client.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Apache HBase Client</technology-tag>
             </perform>
@@ -230,6 +262,8 @@
             <perform>
                 <classification title="Embedded Apache Accumulo Client" category-id="information" effort="0">
                     <description>The application embeds an Apache Accumulo client.</description>
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 6 Supported Configurations" href="https://access.redhat.com/articles/111663" />
+                    <link title="Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations" href="https://access.redhat.com/articles/2026253" />
                 </classification>
                 <technology-tag level="INFORMATIONAL">Apache Accumulo Client</technology-tag>
             </perform>


### PR DESCRIPTION
Added links to existing connect.windup.xml and database.windup.xml rules
All database rules had the links added
Only messaging technologies within the connect.windup.xml have had the links added.
No changes to database.windup.test.xml nor connect.windup.test.xml as it is not possible to test for 'links-exists'.
Nor is it possible to specify which order a links will appear in the issue body, so in my testing the EAP7 link appeared first on the issue Report even though the EAP6 link is first in link within the rule.