### PR TITLE
WINDUPRULE-377: hibernate 5.1-5.3 migration, hibernate-java8 in pom.xml

### DIFF
--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -24,17 +24,30 @@
             </perform>
         </rule>
         -->
-        <!--https://issues.jboss.org/browse/WINDUPRULE-377
+        <!--https://issues.jboss.org/browse/WINDUPRULE-377 -->
         <rule id="hibernate51-53-00100">
             <when>
+                <project>
+                    <artifact groupId="org.hibernate" artifactId="hibernate-java8" />
+                </project>
+                <not>
+                    <project>
+                        <artifact groupId="org.hibernate" artifactId="hibernate-core" />
+                    </project>
+                </not>
             </when>
             <perform>
+                <hint title="Hibernate 5.3 - hibernate-java8 module has been merged into hibernate-core and the Java 8 date/time types are now natively supported." effort="1" category-id="mandatory">
+                    <message>change reference to hibernate-java8 to hibernate-core (since hibernate-java8 has been merged into hibernate-core module) </message>
+                    <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#migrating_from_hibernate_5_1_to_5_3"/>
+                    <tag>hibernate</tag>
+                    <quickfix name="hibernate-java8" type="REPLACE">
+                        <replacement>hibernate-core</replacement>
+                        <search>hibernate-java8</search>
+                    </quickfix>
+                </hint>
             </perform>
-            <where param="">
-                <matches pattern="" />
-            </where>
         </rule>
-        -->
         <!--https://issues.jboss.org/browse/WINDUPRULE-378
         <rule id="hibernate51-53-00200">
             <when>

--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -28,7 +28,7 @@
         <rule id="hibernate51-53-00100">
             <when>
                 <project>
-                    <artifact groupId="org.hibernate" artifactId="hibernate-java8" />
+                    <artifact groupId="org.hibernate" artifactId="{substitution}" />
                 </project>
                 <not>
                     <project>
@@ -41,12 +41,11 @@
                     <message>change reference to hibernate-java8 to hibernate-core (since hibernate-java8 has been merged into hibernate-core module) </message>
                     <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#migrating_from_hibernate_5_1_to_5_3"/>
                     <tag>hibernate</tag>
-                    <quickfix name="hibernate-java8" type="REPLACE">
-                        <replacement>hibernate-core</replacement>
-                        <search>hibernate-java8</search>
-                    </quickfix>
                 </hint>
             </perform>
+            <where param="substitution">
+                <matches pattern="(hibernate-java8|hibernate-entitymanager)" />
+            </where>
         </rule>
         <!--https://issues.jboss.org/browse/WINDUPRULE-378
         <rule id="hibernate51-53-00200">

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/pom.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.windup.rules.test</groupId>
+        <artifactId>windup-rulesets-test-pom</artifactId>
+        <version>4.2.1_SNAPSHOT</version>
+    </parent>
+
+    <artifactId>hibernate</artifactId>
+    <name>Windup - JPA Data Models</name>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-java8</artifactId>
+            <scope>provided</scope>
+            <version>5.0.10.Final</version>
+        </dependency>
+
+
+    </dependencies>
+
+
+</project>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/pom.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/pom.xml
@@ -21,6 +21,15 @@
         </dependency>
 
 
+
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-entitymanager</artifactId>
+            <scope>provided</scope>
+            <version>5.0.10.Final</version>
+        </dependency>
+
+
     </dependencies>
 
 

--- a/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
+++ b/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
@@ -20,20 +20,17 @@
                 </perform>
             </rule>
             -->
-            <!--https://issues.jboss.org/browse/WINDUPRULE-377
+            <!--https://issues.jboss.org/browse/WINDUPRULE-377 -->
             <rule id="hibernate51-53-00100-test">
                 <when>
                     <not>
-                        <iterable-filter size="5">
-                            <hint-exists message="" />
-                        </iterable-filter>
+                        <hint-exists message="change reference to hibernate-java8 to hibernate-core" />
                     </not>
                 </when>
                 <perform>
-                    <fail message="" />
+                    <fail message="No reference to hibernate-java8 found in pom.xml (where hibernate-core not also referenced)" />
                 </perform>
             </rule>
-            -->
             <!--https://issues.jboss.org/browse/WINDUPRULE-378-
             <rule id="hibernate51-53-00200-test">
                 <when>

--- a/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
+++ b/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
@@ -24,7 +24,9 @@
             <rule id="hibernate51-53-00100-test">
                 <when>
                     <not>
-                        <hint-exists message="change reference to hibernate-java8 to hibernate-core" />
+                        <iterable-filter size="2">
+                            <hint-exists message="change reference to hibernate-java8 to hibernate-core" />
+                        </iterable-filter>
                     </not>
                 </when>
                 <perform>


### PR DESCRIPTION
dependent on https://github.com/windup/windup/pull/1348

This PR includes solutions for both WINDUPRULE-377 and WINDUPRULE-378 - they are very similar and can both be solved in the same rule by parameterizing it and passing in the artifactIds we wish to search for in each case: 

hibernate-java8 for WINDUPRULE-377, 
hibernate-entitymanager for WINDUPRULE-378