### PR TITLE
WINDUPRULE-383 SecondLevelCacheStatistics and NaturalIdCacheStatistics deprecated methods

### DIFF
--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -81,17 +81,96 @@
             </perform>
         </rule>
         -->
-        <!--https://issues.jboss.org/browse/WINDUPRULE-383
+        <!--https://issues.jboss.org/browse/WINDUPRULE-383-->
         <rule id="hibernate51-53-00700">
             <when>
+                <javaclass references="org.hibernate.stat.{interfaces}.getEntries()">
+                    <location>METHOD_CALL</location>
+                </javaclass>
             </when>
             <perform>
+                <hint title="Hibernate 5.3 - SecondLevelCacheStatistics.getEntries() and NaturalIdCacheStatistics.getEntries(): deprecated methods" effort="1" category-id="optional">
+                    <message>
+                        A change to be aware of is accessing cache entries via `SecondLevelCacheStatistics.getEntries()` and `NaturalIdCacheStatistics.getEntries()`.  
+                        These methods have been deprecated, however the new caching SPI does not really require caching providers to support this.  
+                        As of Hibernate 5.3 these methods inherently return an empty Map (`Collections#emptyMap`).  
+                        This has always been something that providers did not implement "correctly" anyway.  
+                        Details can be found in HHH-11356 JIRA issue (link below).
+                    </message>
+                    <link href="https://github.com/hibernate/hibernate-orm/blob/5.3/migration-guide.adoc#second-level-cache-provider-spi-changes" title="Hibernate ORM 5.3 Migration Guide: Second-level cache provider SPI changes" />
+                    <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#hibernate_orm_5_3_features"/>
+                    <link href="https://hibernate.atlassian.net/browse/HHH-11356" title="HHH-11356: Adjust the 2nd-Cache SPIs to better reflect supported uses" />
+                    <tag>hibernate</tag>
+                </hint>
             </perform>
-            <where param="">
-                <matches pattern="" />
+            <where param="interfaces">
+                <matches pattern="(SecondLevelCacheStatistics|NaturalIdCacheStatistics)" />
             </where>
         </rule>
-        -->
+        <rule id="hibernate51-53-00701">
+            <when>
+                <javaclass references="{*}.getEntries()" >
+                    <location>METHOD</location>
+                </javaclass>
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <javaclass references="org.hibernate.stat.NaturalIdCacheStatistics">
+                            <location>INHERITANCE</location>
+                            <location>IMPLEMENTS_TYPE</location>
+                        </javaclass>
+                    </when>
+                    <perform>
+                        <hint title="Hibernate 5.3 - NaturalIdCacheStatistics.getEntries() deprecated method" effort="1" category-id="optional">
+                            <message>
+                                A change to be aware of is accessing cache entries via `NaturalIdCacheStatistics.getEntries()`.  
+                                This method has been deprecated, however the new caching SPI does not really require caching providers to support this.  
+                                As of Hibernate 5.3 this method inherently return an empty Map (`Collections#emptyMap`).  
+                                This has always been something that providers did not implement "correctly" anyway.  
+                                Details can be found in HHH-11356 JIRA issue (link below).
+                            </message>
+                            <link href="https://github.com/hibernate/hibernate-orm/blob/5.3/migration-guide.adoc#second-level-cache-provider-spi-changes" title="Hibernate ORM 5.3 Migration Guide: Second-level cache provider SPI changes" />
+                            <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#hibernate_orm_5_3_features"/>
+                            <link href="https://hibernate.atlassian.net/browse/HHH-11356" title="HHH-11356: Adjust the 2nd-Cache SPIs to better reflect supported uses" />
+                            <tag>hibernate</tag>
+                        </hint>
+                    </perform>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="hibernate51-53-00702">
+            <when>
+                <javaclass references="{*}.getEntries()" >
+                    <location>METHOD</location>
+                </javaclass>
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <javaclass references="org.hibernate.stat.SecondLevelCacheStatistics">
+                            <location>INHERITANCE</location>
+                            <location>IMPLEMENTS_TYPE</location>
+                        </javaclass>
+                    </when>
+                    <perform>
+                        <hint title="Hibernate 5.3 - SecondLevelCacheStatistics.getEntries() deprecated method" effort="1" category-id="optional">
+                            <message>
+                                A change to be aware of is accessing cache entries via `SecondLevelCacheStatistics.getEntries()`.  
+                                This method has been deprecated, however the new caching SPI does not really require caching providers to support this.  
+                                As of Hibernate 5.3 these methods inherently return an empty Map (`Collections#emptyMap`).  
+                                This has always been something that providers did not implement "correctly" anyway.  
+                                Details can be found in HHH-11356 JIRA issue (link below).
+                            </message>
+                            <link href="https://github.com/hibernate/hibernate-orm/blob/5.3/migration-guide.adoc#second-level-cache-provider-spi-changes" title="Hibernate ORM 5.3 Migration Guide: Second-level cache provider SPI changes" />
+                            <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#hibernate_orm_5_3_features"/>
+                            <link href="https://hibernate.atlassian.net/browse/HHH-11356" title="HHH-11356: Adjust the 2nd-Cache SPIs to better reflect supported uses" />
+                            <tag>hibernate</tag>
+                        </hint>
+                    </perform>
+                </iteration>
+            </perform>
+        </rule>
         <!--https://issues.jboss.org/browse/WINDUPRULE-384
         <rule id="hibernate51-53-00800">
             <when>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300700.java
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300700.java
@@ -1,0 +1,13 @@
+import org.hibernate.stat.SecondLevelCacheStatistics;
+import org.hibernate.stat.NaturalIdCacheStatistics;
+import org.hibernate.SessionFactory;
+
+public class Hibernate515300700 {
+
+    public void aMethod(SessionFactory sf) {
+        SecondLevelCacheStatistics secondLevelCacheStatistics = sf.getStatistics().getSecondLevelCacheStatistics("CACHE_ENTITY");
+        secondLevelCacheStatistics.getEntries();
+        NaturalIdCacheStatistics naturalIdCacheStatistics = sf.getStatistics().getNaturalIdCacheStatistics("CACHE_PROPERTY");
+        naturalIdCacheStatistics.getEntries();
+    }
+}

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300701.java
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300701.java
@@ -1,0 +1,177 @@
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+
+import org.hibernate.cache.spi.Region;
+import org.hibernate.cache.spi.access.NaturalIdRegionAccessStrategy;
+import org.hibernate.stat.NaturalIdCacheStatistics;
+
+public class Hibernate515300701 extends CategorizedStatistics implements NaturalIdCacheStatistics {
+    private static final long serialVersionUID = 1L;
+    private final transient Region region;
+    private final transient NaturalIdRegionAccessStrategy accessStrategy;
+    private final AtomicLong hitCount = new AtomicLong();
+    private final AtomicLong missCount = new AtomicLong();
+    private final AtomicLong putCount = new AtomicLong();
+    private final AtomicLong executionCount = new AtomicLong();
+    private final AtomicLong executionMaxTime = new AtomicLong();
+    private final AtomicLong executionMinTime = new AtomicLong( Long.MAX_VALUE );
+    private final AtomicLong totalExecutionTime = new AtomicLong();
+
+    private final Lock readLock;
+    private final Lock writeLock;
+
+    {
+        final ReadWriteLock lock = new ReentrantReadWriteLock();
+        this.readLock = lock.readLock();
+        this.writeLock = lock.writeLock();
+    }
+
+    ConcurrentNaturalIdCacheStatisticsImpl(Region region, NaturalIdRegionAccessStrategy accessStrategy) {
+        super( region.getName() );
+        this.region = region;
+        this.accessStrategy = accessStrategy;
+    }
+
+    @Override
+    public long getHitCount() {
+        return this.hitCount.get();
+    }
+
+    @Override
+    public long getMissCount() {
+        return this.missCount.get();
+    }
+
+    @Override
+    public long getPutCount() {
+        return this.putCount.get();
+    }
+
+    /**
+     * queries executed to the DB
+     */
+    @Override
+    public long getExecutionCount() {
+        return this.executionCount.get();
+    }
+
+    /**
+     * average time in ms taken by the excution of this query onto the DB
+     */
+    @Override
+    public long getExecutionAvgTime() {
+        // We write lock here to be sure that we always calculate the average time
+        // with all updates from the executed applied: executionCount and totalExecutionTime
+        // both used in the calculation
+        this.writeLock.lock();
+        try {
+            long avgExecutionTime = 0;
+            if ( this.executionCount.get() > 0 ) {
+                avgExecutionTime = this.totalExecutionTime.get() / this.executionCount.get();
+            }
+            return avgExecutionTime;
+        }
+        finally {
+            this.writeLock.unlock();
+        }
+    }
+
+    /**
+     * max time in ms taken by the excution of this query onto the DB
+     */
+    @Override
+    public long getExecutionMaxTime() {
+        return this.executionMaxTime.get();
+    }
+
+    /**
+     * min time in ms taken by the excution of this query onto the DB
+     */
+    @Override
+    public long getExecutionMinTime() {
+        return this.executionMinTime.get();
+    }
+
+    @Override
+    public long getElementCountInMemory() {
+        return this.region.getElementCountInMemory();
+    }
+
+    @Override
+    public long getElementCountOnDisk() {
+        return this.region.getElementCountOnDisk();
+    }
+
+    @Override
+    public long getSizeInMemory() {
+        return this.region.getSizeInMemory();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public Map getEntries() {
+        final Map map = new HashMap();
+        for ( Object o : this.region.toMap().entrySet() ) {
+            Map.Entry me = (Map.Entry) o;
+            map.put( accessStrategy.getNaturalIdValues(me.getKey()), me.getValue() );
+        }
+        return map;
+    }
+
+    @Override
+    public String toString() {
+        final StringBuilder buf = new StringBuilder()
+                .append( "NaturalIdCacheStatistics" )
+                .append( "[hitCount=" ).append( this.hitCount )
+                .append( ",missCount=" ).append( this.missCount )
+                .append( ",putCount=" ).append( this.putCount )
+                .append( ",executionCount=" ).append( this.executionCount )
+                .append( ",executionAvgTime=" ).append( this.getExecutionAvgTime() )
+                .append( ",executionMinTime=" ).append( this.executionMinTime )
+                .append( ",executionMaxTime=" ).append( this.executionMaxTime );
+        // not sure if this would ever be null but wanted to be careful
+        if ( this.region != null ) {
+            buf.append( ",elementCountInMemory=" ).append( this.getElementCountInMemory() )
+                    .append( ",elementCountOnDisk=" ).append( this.getElementCountOnDisk() )
+                    .append( ",sizeInMemory=" ).append( this.getSizeInMemory() );
+        }
+        buf.append( ']' );
+        return buf.toString();
+    }
+
+    void incrementHitCount() {
+        this.hitCount.getAndIncrement();
+    }
+
+    void incrementMissCount() {
+        this.missCount.getAndIncrement();
+    }
+
+    void incrementPutCount() {
+        this.putCount.getAndIncrement();
+    }
+
+    void queryExecuted(long time) {
+        // read lock is enough, concurrent updates are supported by the underlying type AtomicLong
+        // this only guards executed(long, long) to be called, when another thread is executing getExecutionAvgTime()
+        this.readLock.lock();
+        try {
+            // Less chances for a context switch
+            //noinspection StatementWithEmptyBody
+            for ( long old = this.executionMinTime.get(); time < old && !this.executionMinTime.compareAndSet( old, time ); old = this.executionMinTime.get() ) {
+            }
+            //noinspection StatementWithEmptyBody
+            for ( long old = this.executionMaxTime.get(); time > old && !this.executionMaxTime.compareAndSet( old, time ); old = this.executionMaxTime.get() ) {
+            }
+            this.executionCount.getAndIncrement();
+            this.totalExecutionTime.addAndGet( time );
+        }
+        finally {
+            this.readLock.unlock();
+        }
+    }
+}

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300702.java
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate515300702.java
@@ -1,0 +1,97 @@
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.hibernate.cache.spi.Region;
+import org.hibernate.cache.spi.access.CollectionRegionAccessStrategy;
+import org.hibernate.cache.spi.access.EntityRegionAccessStrategy;
+import org.hibernate.stat.SecondLevelCacheStatistics;
+
+public class Hibernate515300702 extends CategorizedStatistics implements SecondLevelCacheStatistics {
+    private final transient Region region;
+    private final transient EntityRegionAccessStrategy entityRegionAccessStrategy;
+    private final transient CollectionRegionAccessStrategy collectionRegionAccessStrategy;
+    private AtomicLong hitCount = new AtomicLong();
+    private AtomicLong missCount = new AtomicLong();
+    private AtomicLong putCount = new AtomicLong();
+
+    ConcurrentSecondLevelCacheStatisticsImpl(Region region,
+                                             EntityRegionAccessStrategy entityRegionAccessStrategy,
+                                             CollectionRegionAccessStrategy collectionRegionAccessStrategy) {
+        super( region.getName() );
+        this.region = region;
+        this.entityRegionAccessStrategy = entityRegionAccessStrategy;
+        this.collectionRegionAccessStrategy = collectionRegionAccessStrategy;
+    }
+
+    public long getHitCount() {
+        return hitCount.get();
+    }
+
+    public long getMissCount() {
+        return missCount.get();
+    }
+
+    public long getPutCount() {
+        return putCount.get();
+    }
+
+    public long getElementCountInMemory() {
+        return region.getElementCountInMemory();
+    }
+
+    public long getElementCountOnDisk() {
+        return region.getElementCountOnDisk();
+    }
+
+    public long getSizeInMemory() {
+        return region.getSizeInMemory();
+    }
+
+    public Map getEntries() {
+        Map map = new HashMap();
+        for ( Object o : region.toMap().entrySet() ) {
+            Map.Entry me = (Map.Entry) o;
+            Object id;
+            if ( entityRegionAccessStrategy != null ) {
+                id = entityRegionAccessStrategy.getCacheKeyId( me.getKey() );
+            }
+            else if ( collectionRegionAccessStrategy != null ) {
+                id = collectionRegionAccessStrategy.getCacheKeyId( me.getKey() );
+            }
+            else {
+                id = me.getKey();
+            }
+            map.put( id, me.getValue() );
+        }
+        return map;
+    }
+
+    public String toString() {
+        StringBuilder buf = new StringBuilder()
+                .append( "SecondLevelCacheStatistics" )
+                .append( "[hitCount=").append( this.hitCount )
+                .append( ",missCount=").append( this.missCount )
+                .append( ",putCount=").append( this.putCount );
+        //not sure if this would ever be null but wanted to be careful
+        if ( region != null ) {
+            buf.append( ",elementCountInMemory=" ).append( this.getElementCountInMemory() )
+                    .append( ",elementCountOnDisk=" ).append( this.getElementCountOnDisk() )
+                    .append( ",sizeInMemory=" ).append( this.getSizeInMemory() );
+        }
+        buf.append( ']' );
+        return buf.toString();
+    }
+
+    void incrementHitCount() {
+        hitCount.getAndIncrement();
+    }
+
+    void incrementMissCount() {
+        missCount.getAndIncrement();
+    }
+
+    void incrementPutCount() {
+        putCount.getAndIncrement();
+    }
+}

--- a/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
+++ b/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
@@ -3,6 +3,7 @@
           id="hibernate51-53-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <testDataPath>data/data-hibernate51-53/</testDataPath>
+    <!--<testDataPath>data/hibernate-core-5.1.6.Final-sources/</testDataPath>-->
     <rulePath>../hibernate51-53.windup.xml</rulePath>
     <ruleset>
         <rules>
@@ -104,20 +105,44 @@
                 </perform>
             </rule>
             -->
-            <!--https://issues.jboss.org/browse/WINDUPRULE-383-
+            <!--https://issues.jboss.org/browse/WINDUPRULE-383-->
             <rule id="hibernate51-53-00700-test">
                 <when>
                     <not>
-                        <iterable-filter size="5">
-                            <hint-exists message="" />
+                        <iterable-filter size="2">
+                            <hint-exists message="A change to be aware of is accessing cache entries via `SecondLevelCacheStatistics.getEntries\(\)` and `NaturalIdCacheStatistics.getEntries\(\)`*" />
                         </iterable-filter>
                     </not>
                 </when>
                 <perform>
-                    <fail message="" />
+                    <fail message="Hint deprecated methods SecondLevelCacheStatistics.getEntries and NaturalIdCacheStatistics.getEntries not found" />
                 </perform>
             </rule>
-            -->
+            <rule id="hibernate51-53-00701-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="A change to be aware of is accessing cache entries via `NaturalIdCacheStatistics.getEntries\(\)`*" />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Hint deprecated method NaturalIdCacheStatistics.getEntries not found" />
+                </perform>
+            </rule>
+            <rule id="hibernate51-53-00702-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="A change to be aware of is accessing cache entries via `SecondLevelCacheStatistics.getEntries\(\)`\." />
+                            <!--<hint-exists message="A change to be aware of is accessing cache entries via `SecondLevelCacheStatistics.getEntries\(\)`.*[\n]*.*This method  has been deprecated" />-->
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Hint deprecated method SecondLevelCacheStatistics.getEntries not found" />
+                </perform>
+            </rule>
             <!--https://issues.jboss.org/browse/WINDUPRULE-384
             <rule id="hibernate51-53-00800-test">
                 <when>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUPRULE-383

I created rules `hibernate51-53-00701` and `hibernate51-53-00702` because using a parameter for the implemented classes (`SecondLevelCacheStatistics` and  `NaturalIdCacheStatistics`) didn't work.