### PR TITLE
WINDUPRULE-386 Fix the case when Hibernate is not used

### DIFF
--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -400,7 +400,7 @@
         <rule id="hibernate51-53-01000">
             <when>
                 <and>
-                    <xmlfile matches="//s:persistence-unit" as="persistence_files">
+                    <xmlfile matches="//s:persistence-unit/s:provider[starts-with(text(), 'org.hibernate')]" as="persistence_files">
                         <namespace prefix="s" uri="http://java.sun.com/xml/ns/persistence"/>
                     </xmlfile>
                     <xmlfile matches="//s:properties[count(s:property[@name='hibernate.default_schema'])=0 and count(s:property[@name='hibernate.default_catalog'])=0]" from="persistence_files" as="wrong_files">

--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -418,6 +418,25 @@
                 </iteration>
             </perform>
         </rule>
+        <rule id="hibernate51-53-01001">
+            <when>
+                <xmlfile matches="//s:persistence-unit[not(s:provider) or s:provider[not(text())]]" as="persistence_files">
+                    <namespace prefix="s" uri="http://java.sun.com/xml/ns/persistence"/>
+                </xmlfile>
+                <xmlfile matches="//s:properties[count(s:property[@name='hibernate.default_schema'])=0 and count(s:property[@name='hibernate.default_catalog'])=0]" from="persistence_files" as="wrong_files">
+                    <namespace prefix="s" uri="http://java.sun.com/xml/ns/persistence"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="wrong_files">
+                    <hint title="Hibernate 5.3 - default_schema or default_catalog must be defined or set jdbc_metadata_extraction_strategy" category-id="potential" effort="1">
+                        <message>If the application uses Hibernate, please define `hibernate.default_schema` or `hibernate.default_catalog` (whichever is used by the selected dialect), or, alternatively, set `hibernate.hbm2ddl.jdbc_metadata_extraction_strategy=individually`.</message>
+                        <link title="Red Hat JBoss EAP 7.2: Migrating from Hibernate ORM 5.1 to Hibernate ORM 5.3" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.2/html-single/migration_guide/#schema_management_tooling_changes_71"/>
+                        <tag>hibernate</tag>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
         <!--https://issues.jboss.org/browse/WINDUPRULE-387-->
         <rule id="hibernate51-53-01100">
             <when>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-eclipselink.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-eclipselink.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence version="2.0" xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd">
+    <persistence-unit name="com.mycompany_MavenEnterpriseApp-ejb_ejb_1.0-SNAPSHOTPU" transaction-type="JTA">
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+        <jta-data-source>jdbc/sample</jta-data-source>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="eclipselink.ddl-generation" value="create-tables"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-empty-provider-default-schema.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-empty-provider-default-schema.xml
@@ -1,0 +1,14 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="sample">
+        <provider/>
+        <jta-data-source>java:/DefaultDS</jta-data-source>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.default_schema" value="myschema"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-empty-provider.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-empty-provider.xml
@@ -1,0 +1,13 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="sample">
+        <provider/>
+        <jta-data-source>java:/DefaultDS</jta-data-source>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-without-provider-default-catalog.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-without-provider-default-catalog.xml
@@ -1,0 +1,13 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="sample">
+        <jta-data-source>java:/DefaultDS</jta-data-source>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+            <property name="hibernate.default_catalog" value="mycatalog"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-without-provider.xml
+++ b/rules-reviewed/eap7/eap71/tests/data/data-hibernate51-53/Hibernate5153-01000-persistence-without-provider.xml
@@ -1,0 +1,12 @@
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="sample">
+        <jta-data-source>java:/DefaultDS</jta-data-source>
+        <properties>
+            <property name="hibernate.dialect" value="org.hibernate.dialect.HSQLDialect"/>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
+++ b/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml
@@ -234,6 +234,18 @@
                     <fail message="No default_schema or default_catalog found"/>
                 </perform>
             </rule>
+            <rule id="hibernate51-53-01001-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="If the application uses Hibernate, please define `hibernate.default_schema` or `hibernate.default_catalog`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="No default_schema or default_catalog found"/>
+                </perform>
+            </rule>
             <!--https://issues.jboss.org/browse/WINDUPRULE-387-->
             <rule id="hibernate51-53-01100-test">
                 <when>


### PR DESCRIPTION
Fix for [WINDUPRULE-386](https://issues.jboss.org/browse/WINDUPRULE-386?focusedCommentId=13708852&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-13708852)

Added a test file [Hibernate5153-01000-persistence-eclipselink.xml](https://github.com/windup/windup-rulesets/compare/master...mrizzi:WINDUPRULE-386?expand=1#diff-0302e37fd2b734f35a1a0560d4f42609) that made the test [hibernate51-53-01000-test](https://github.com/windup/windup-rulesets/blob/master/rules-reviewed/eap7/eap71/tests/hibernate51-53.windup.test.xml#L225) failing and then applied the fix to the rule.