### PR TITLE
WINDUPRULE-393 'context' attribute removed

### DIFF
--- a/rules-reviewed/camel3/camel2/java-multiple-camelcontexts-per-application-not-supported.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-multiple-camelcontexts-per-application-not-supported.windup.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="java-multiple-camelcontexts-per-application-not-supported"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis with respect to multiple Camel Context not supported in Apache Camel 3.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="camel" versionRange="[2,3)"/>
+        <targetTechnology id="camel" versionRange="[3,)" />
+    </metadata>
+    <rules>
+        <rule id="java-multiple-camelcontexts-per-application-not-supported-00000">
+            <when>
+                <javaclass references="org.apache.camel.{class}">
+                    <location>ANNOTATION</location>
+                    <annotation-literal name="context" pattern="{*}" />
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="{class}: `context` attribute removed" effort="1" category-id="mandatory">
+                    <message>
+                        The `context` attribute on `{class}` annotations has been removed since support for multiple CamelContexts has been removed and only one CamelContext per deployment is supported.
+                    </message>
+                    <link title="Camel 3 - Migration Guide: multiple CamelContexts per application not supported" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_multiple_camelcontexts_per_application_not_supported" />
+                </hint>
+            </perform>
+            <where param="class">
+                <!-- taken from https://github.com/apache/camel/commit/87998250fb56e561643e192874ba00c5ff3a1b9c -->
+                <matches pattern="(BeanInject|Consume|DynamicRouter|EndpointInject|Produce|PropertyInject|RecipientList|RoutingSlip)" />
+            </where>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/camel3/camel2/tests/data/java-multiple-camelcontexts-per-application-not-supported/Removed.java
+++ b/rules-reviewed/camel3/camel2/tests/data/java-multiple-camelcontexts-per-application-not-supported/Removed.java
@@ -1,0 +1,63 @@
+package org.jboss.xavier.integrations.route;
+
+import org.apache.camel.BeanInject;
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.Consume;
+import org.apache.camel.DynamicRouter;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Produce;
+import org.apache.camel.ProducerTemplate;
+import org.apache.camel.PropertyInject;
+import org.apache.camel.RecipientList;
+import org.apache.camel.RoutingSlip;
+
+import java.util.function.BiFunction;
+
+public class Removed
+{
+    @BeanInject(value = "foo", context = "context-0")
+    Object foo;
+
+    @BeanInject("foo2")
+    Object foo2;
+
+    @EndpointInject(uri="activemq:foo.bar", context = "context-0")
+    ProducerTemplate producerTemplate;
+
+    @EndpointInject(uri="activemq:foo.bar")
+    ProducerTemplate producerTemplate2;
+
+    @Produce(uri = "activemq:foo", context = "context-1")
+    Object object;
+
+    @Produce(uri = "activemq:foo")
+    Object anotherObject;
+
+    @Consume(uri="activemq:cheese", context = "context-2")
+    @DynamicRouter(delimiter = ".", context = "context-2")
+    public void onCheese(String name) {}
+
+    @Consume(uri="activemq:cheese")
+    @DynamicRouter(context = "context-2")
+    public void onCheese2(String name) {}
+
+    @PropertyInject(value = "hello", context = "context-3")
+    private String greeting;
+
+    @PropertyInject("cheers")
+    private String cheers;
+
+    @RecipientList(context = "context-0")
+    @RoutingSlip(delimiter = ".")
+    public String routeTo() {
+        String queueName = "activemq:queue:test2";
+        return queueName;
+    }
+
+    @RecipientList(streaming = true)
+    @RoutingSlip(context = "context-2")
+    public String routeTo2() {
+        String queueName = "activemq:queue:test2";
+        return queueName;
+    }
+}

--- a/rules-reviewed/camel3/camel2/tests/java-multiple-camelcontexts-per-application-not-supported.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-multiple-camelcontexts-per-application-not-supported.windup.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruletest id="java-multiple-camelcontexts-per-application-not-supported-tests"
+    xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/java-multiple-camelcontexts-per-application-not-supported</testDataPath>
+    <rulePath>../java-multiple-camelcontexts-per-application-not-supported.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="java-multiple-camelcontexts-per-application-not-supported-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="9">
+                            <hint-exists message="The `context` attribute on*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-multiple-camelcontexts-per-application-not-supported] 'context' attribute removed hint was not found!" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUPRULE-393

To run the validation test execute:
`$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-multiple-camelcontexts-per-application-not-supported clean surefire-report:report`