### PR TITLE
WINDUPRULE-408 camel-linkedin removed

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>0.0.1</version>
+    <name>Sample Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-linkedin</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/rules-reviewed/camel3/camel2/tests/xml-removed-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-removed-components.windup.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruletest id="xml-removed-components-tests"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/xml-removed-components</testDataPath>
+    <rulePath>../xml-removed-components.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="xml-removed-components-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="`org.apache.camel:camel-linkedin` artifact has been removed in Apache Camel 3 so it won't be available"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-removed-components] 'camel-linkedin' dependency removed hint was not found!" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xml-removed-components"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            Rules for changes in XML file (e.g. pom.xml) to run on Apache Camel 3
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="camel" versionRange="[2,3)"/>
+        <targetTechnology id="camel" versionRange="[3,)" />
+    </metadata>
+    <rules>
+        <rule id="xml-removed-components-00000">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-linkedin" />
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-linkedin` artifact has been removed" effort="7" category-id="mandatory" >
+                    <message>`org.apache.camel:camel-linkedin` artifact has been removed in Apache Camel 3 so it won't be available</message>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>
+


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUPRULE-408

Tested running `$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-removed-components clean surefire-report:report`