### PR TITLE
WINDUPRULE-409 camel-http4 renamed

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>0.0.1</version>
+    <name>Sample Project</name>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-http4</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruletest id="FIX_RULESET_ID-tests"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/xml-renamed-components</testDataPath>
+    <rulePath>../xml-renamed-components.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="xml-renamed-components-00000-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="`org.apache.camel:camel-http4` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-http` artifact"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-renamed-components] 'camel-http4' dependency moved hint was not found!" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="xml-renamed-components"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            Rules for changes in XML file (e.g. pom.xml) to run on Apache Camel 3
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="camel" versionRange="[2,3)"/>
+        <targetTechnology id="camel" versionRange="[3,)" />
+    </metadata>
+    <rules>
+        <rule id="xml-renamed-components-00000">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-http4" />
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-http4` artifact has been renamed" effort="1" category-id="mandatory" >
+                    <message>`org.apache.camel:camel-http4` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-http` artifact</message>
+                    <quickfix type="REPLACE" name="camel-http4-replace">
+                        <replacement>camel-http</replacement>
+                        <search>camel-http4</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>
+


### PR DESCRIPTION
https://issues.jboss.org/browse/WINDUPRULE-409

Tested executing `$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-renamed-components clean surefire-report:report`