### PR TITLE
WINDUPRULE-403 SessionBean interface removed

### DIFF
--- a/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.groovy
+++ b/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.groovy
@@ -4,7 +4,6 @@ import org.jboss.windup.config.parameters.ParameterizedIterationOperation
 import org.jboss.windup.config.query.Query
 import org.jboss.windup.reporting.category.IssueCategoryRegistry
 import org.jboss.windup.reporting.config.Hint
-import org.jboss.windup.reporting.config.Link
 import org.jboss.windup.rules.apps.java.model.JavaClassModel
 import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel
 import org.jboss.windup.rules.apps.java.service.TypeReferenceService
@@ -36,7 +35,6 @@ ruleSet("singleton-sessionbean-groovy")
                             ```
                             """)
                     .withIssueCategory(new IssueCategoryRegistry().getByID(IssueCategoryRegistry.MANDATORY))
-                    .with(Link.to("FIXME", "FIXME"))
                     .withEffort(1);
 
             Set<String> getRequiredParameterNames() {

--- a/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.groovy
+++ b/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.groovy
@@ -1,0 +1,66 @@
+import org.jboss.windup.config.GraphRewrite
+import org.jboss.windup.config.metadata.TechnologyReference
+import org.jboss.windup.config.parameters.ParameterizedIterationOperation
+import org.jboss.windup.config.query.Query
+import org.jboss.windup.reporting.category.IssueCategoryRegistry
+import org.jboss.windup.reporting.config.Hint
+import org.jboss.windup.reporting.config.Link
+import org.jboss.windup.rules.apps.java.model.JavaClassModel
+import org.jboss.windup.rules.apps.java.scan.ast.JavaTypeReferenceModel
+import org.jboss.windup.rules.apps.java.service.TypeReferenceService
+import org.jboss.windup.rules.apps.javaee.model.EjbSessionBeanModel
+import org.ocpsoft.rewrite.context.EvaluationContext
+import org.ocpsoft.rewrite.param.ParameterStore
+
+ruleSet("singleton-sessionbean-groovy")
+    .addTargetTechnology(new TechnologyReference("eap", "[7,8)"))
+    .addRule()
+    .when(Query.fromType(EjbSessionBeanModel.class).withProperty("sessionType", "Singleton"))
+    .perform(
+        new ParameterizedIterationOperation<EjbSessionBeanModel>() {
+            Hint hint = Hint
+                    .titled("Removed SessionBean interface")
+                    .withText(
+                            """When a singleton EJB bean class implements `javax.ejb.SessionBean` interface, this interface should be removed from the implements clause.  
+                            All methods declared in `javax.ejb.SessionBean` interface (see below) that are implemented in the bean class or its super classes should be checked for `@Override` annotation and remove this annotation too if present.  
+                            Methods declared by `javax.ejb.SessionBean` interface:  
+                            
+                            ```
+                            void setSessionContext(SessionContext ctx);  
+                            
+                            void ejbRemove();  
+                            
+                            void ejbActivate();  
+                            
+                            void ejbPassivate();  
+                            ```
+                            """)
+                    .withIssueCategory(new IssueCategoryRegistry().getByID(IssueCategoryRegistry.MANDATORY))
+                    .with(Link.to("FIXME", "FIXME"))
+                    .withEffort(1);
+
+            Set<String> getRequiredParameterNames() {
+                return hint.getRequiredParameterNames();
+            }
+
+            void setParameterStore(ParameterStore store) {
+                hint.setParameterStore(store);
+            }
+
+            void performParameterized(final GraphRewrite event, final EvaluationContext context, final EjbSessionBeanModel ejbSessionBeanModel) {
+                JavaClassModel ejbJavaClassModel = ejbSessionBeanModel.getEjbClass()
+                List<JavaClassModel> interfaces = ejbJavaClassModel.getInterfaces()
+                interfaces.each{
+                    if ("javax.ejb.SessionBean" == it.getQualifiedName())
+                    {
+                        TypeReferenceService typeReferenceService = new TypeReferenceService(event.getGraphContext())
+                        JavaTypeReferenceModel javaTypeReferenceModel = typeReferenceService.getUniqueByProperty(JavaTypeReferenceModel.RESOLVED_SOURCE_SNIPPIT, ejbJavaClassModel.getQualifiedName())
+                        hint.perform(event, context, javaTypeReferenceModel)
+                        return true
+                    }
+                }
+            }
+        }
+    )
+    .withId("singleton-sessionbean-groovy-00001")
+

--- a/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="singleton-sessionbean"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis of any java class with type annotation javax.ejb.Singleton that also implement interface javax.ejb.SessionBean because SessionBean API was deprecated starting with JBoss EAP 7.3.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <targetTechnology id="eap" versionRange="[7,8)" />
+    </metadata>
+    <rules>
+        <!-- https://issues.redhat.com/browse/WINDUPRULE-403 -->
+        <rule id="singleton-sessionbean-00001">
+            <when>
+                <javaclass references="javax.ejb.Singleton" as="singleton">
+                    <location>ANNOTATION</location>
+                </javaclass>
+                <javaclass references="javax.ejb.SessionBean" from="singleton" as="sessionbean">
+                    <location>IMPLEMENTS_TYPE</location>
+                </javaclass>
+            </when>
+            <perform>
+                <iteration over="sessionbean">
+                    <hint title="Removed SessionBean interface" effort="1" category-id="mandatory">
+                        <message>
+                            <![CDATA[
+                            The `javax.ejb.SessionBean` interface should be removed from the implements clause.  
+                            All methods declared in `javax.ejb.SessionBean` interface (see below) that are implemented in the bean class or its super classes should be checked for `@Override` annotation and remove this annotation too if present.  
+                            Methods declared by `javax.ejb.SessionBean` interface:  
+                            
+                            ```
+                            void setSessionContext(SessionContext ctx);  
+                            
+                            void ejbRemove();  
+                            
+                            void ejbActivate();  
+                            
+                            void ejbPassivate();  
+                            ```
+                            ]]>
+                        </message>
+                        <link title="FIXME" href="FIXME"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
@@ -43,7 +43,6 @@
                             ```
                             ]]>
                         </message>
-                        <link title="FIXME" href="FIXME"/>
                     </hint>
                 </iteration>
             </perform>

--- a/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/singleton-sessionbean.rhamt.xml
@@ -28,7 +28,7 @@
                     <hint title="Removed SessionBean interface" effort="1" category-id="mandatory">
                         <message>
                             <![CDATA[
-                            The `javax.ejb.SessionBean` interface should be removed from the implements clause.  
+                            When a singleton EJB bean class implements `javax.ejb.SessionBean` interface, this interface should be removed from the implements clause.  
                             All methods declared in `javax.ejb.SessionBean` interface (see below) that are implemented in the bean class or its super classes should be checked for `@Override` annotation and remove this annotation too if present.  
                             Methods declared by `javax.ejb.SessionBean` interface:  
                             

--- a/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/AnotherCounter.java
+++ b/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/AnotherCounter.java
@@ -1,0 +1,27 @@
+package org.jboss.as.quickstarts.singleton;
+
+import java.rmi.RemoteException;
+import javax.ejb.SessionBean;
+import javax.ejb.EJBException;
+
+public class AnotherCounter implements SessionBean {
+    @Override
+    public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+}

--- a/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/Counter.java
+++ b/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/Counter.java
@@ -1,0 +1,27 @@
+package org.jboss.as.quickstarts.singleton;
+
+import java.rmi.RemoteException;
+import javax.ejb.SessionBean;
+import javax.ejb.EJBException;
+
+public class Counter implements SessionBean {
+    @Override
+    public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbRemove() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbActivate() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void ejbPassivate() throws EJBException, RemoteException {
+        // TODO Auto-generated method stub
+    }
+}

--- a/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/SingletonBean.java
+++ b/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/SingletonBean.java
@@ -1,0 +1,59 @@
+import java.rmi.RemoteException;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJBException;
+import javax.ejb.SessionBean;
+import javax.ejb.SessionContext;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+@Singleton
+@Startup
+public class SingletonBean implements SessionBean {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = Logger.getLogger(SingletonBean.class.getName());
+
+	@PostConstruct
+	public void start() {
+		LOGGER.info(">>>>>>>> STARTING [" + this.getClass().getSimpleName() + "]");
+	}
+
+	// not called by EAP
+	@PreDestroy
+	public void stop() {
+		LOGGER.info(">>>>>>>> DESTROYING [" + this.getClass().getSimpleName() + "]");
+
+	}
+
+	@Override
+	public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void ejbRemove() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void ejbActivate() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	@Override
+	public void ejbPassivate() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+}
+

--- a/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/SingletonNoSessionBeanBean.java
+++ b/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/SingletonNoSessionBeanBean.java
@@ -1,0 +1,54 @@
+import java.rmi.RemoteException;
+import java.util.logging.Logger;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.ejb.EJBException;
+import javax.ejb.SessionContext;
+import javax.ejb.Singleton;
+import javax.ejb.Startup;
+
+@Singleton
+@Startup
+public class SingletonBean {
+
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 1L;
+
+	private static final Logger LOGGER = Logger.getLogger(SingletonBean.class.getName());
+
+	@PostConstruct
+	public void start() {
+		LOGGER.info(">>>>>>>> STARTING [" + this.getClass().getSimpleName() + "]");
+	}
+
+	// not called by EAP
+	@PreDestroy
+	public void stop() {
+		LOGGER.info(">>>>>>>> DESTROYING [" + this.getClass().getSimpleName() + "]");
+
+	}
+
+	public void setSessionContext(SessionContext ctx) throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	public void ejbRemove() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	public void ejbActivate() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+
+	public void ejbPassivate() throws EJBException, RemoteException {
+		// TODO Auto-generated method stub
+
+	}
+}
+

--- a/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/ejb-jar.xml
+++ b/rules-reviewed/eap7/eap72/tests/data/singleton-sessionbean/ejb-jar.xml
@@ -1,0 +1,15 @@
+<ejb-jar xmlns="http://xmlns.jcp.org/xml/ns/javaee" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://xmlns.jcp.org/xml/ns/javaee http://xmlns.jcp.org/xml/ns/javaee/ejb-jar_3_2.xsd" version="3.2">
+    <enterprise-beans>
+        <session>
+            <ejb-name>Counter</ejb-name>
+            <ejb-class>org.jboss.as.quickstarts.singleton.Counter</ejb-class>
+            <session-type>Singleton</session-type>
+        </session>
+        <session>
+            <ejb-name>AnotherCounter</ejb-name>
+            <ejb-class>org.jboss.as.quickstarts.singleton.AnotherCounter</ejb-class>
+            <session-type>Stateless</session-type>
+        </session>
+    </enterprise-beans>
+</ejb-jar>

--- a/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
+++ b/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
@@ -11,12 +11,12 @@
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="The `javax.ejb.SessionBean` interface should be removed from the implements clause*" />
+                            <hint-exists message="When a singleton EJB bean class implements `javax.ejb.SessionBean` interface, this interface should be removed from the implements clause.*" />
                         </iterable-filter>
                     </not>
                 </when>
                 <perform>
-                    <fail message="No import of `org.wildfly.clustering.singleton.SingletonPolicy` found in ServiceActivator.java" />
+                    <fail message="No hint found for `javax.ejb.SessionBean` interface removed" />
                 </perform>
             </rule>
         </rules>

--- a/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
+++ b/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
@@ -4,13 +4,14 @@
           xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <testDataPath>data/singleton-sessionbean/</testDataPath>
     <rulePath>../singleton-sessionbean.rhamt.xml</rulePath>
+    <rulePath>../singleton-sessionbean.rhamt.groovy</rulePath>
     <ruleset>
         <rules>
             <!-- https://issues.redhat.com/browse/WINDUPRULE-403 -->
             <rule id="singleton-sessionbean-00001-test">
                 <when>
                     <not>
-                        <iterable-filter size="1">
+                        <iterable-filter size="2">
                             <hint-exists message="When a singleton EJB bean class implements `javax.ejb.SessionBean` interface, this interface should be removed from the implements clause.*" />
                         </iterable-filter>
                     </not>

--- a/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
+++ b/rules-reviewed/eap7/eap72/tests/singleton-sessionbean.rhamt.test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          id="singleton-sessionbean-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/singleton-sessionbean/</testDataPath>
+    <rulePath>../singleton-sessionbean.rhamt.xml</rulePath>
+    <ruleset>
+        <rules>
+            <!-- https://issues.redhat.com/browse/WINDUPRULE-403 -->
+            <rule id="singleton-sessionbean-00001-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The `javax.ejb.SessionBean` interface should be removed from the implements clause*" />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="No import of `org.wildfly.clustering.singleton.SingletonPolicy` found in ServiceActivator.java" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-403

Hi @emmartins, in the end it has been quicker to create the rule, i hope you don't mind.
I put in the message, the text your provides in Jira's description and the link has the `FIXME` placeholders.

I also added another test class (other than the one provided in Jira) to have a class "fixed" that has not to fire the rule.

Could you please review the message and provide links? And obviously comment whatever else you want (rule file names, mandatory category, etc)
