### PR TITLE
WINDUPRULE-391 Add some missing links

### DIFF
--- a/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
@@ -21,6 +21,7 @@
             <perform>
                 <hint title="`org.apache.camel:camel-linkedin` artifact has been removed" effort="7" category-id="mandatory" >
                     <message>`org.apache.camel:camel-linkedin` artifact has been removed in Apache Camel 3 so it won't be available</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_removed_components" title="Camel 3 - Migration Guide: Removed components" />
                 </hint>
             </perform>
         </rule>

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -21,6 +21,7 @@
             <perform>
                 <hint title="`org.apache.camel:camel-http4` artifact has been renamed" effort="1" category-id="mandatory" >
                     <message>`org.apache.camel:camel-http4` artifact has been renamed in Apache Camel 3 to `org.apache.camel:camel-http` artifact</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_renamed_components" title="Camel 3 - Migration Guide: Renamed components" />
                     <quickfix type="REPLACE" name="camel-http4-replace">
                         <replacement>camel-http</replacement>
                         <search>camel-http4</search>


### PR DESCRIPTION
Reviewing https://github.com/windup/windup-rulesets/pull/389 i figured out that some rules are missing the link to the Camel 3 Migration guide so i created this PR to fix it.

@johnpoth in https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_removed_components `camel-linkedin` is not mentioned: do you think it's worth changing the Camel 3 Migration Guide to include it?