### PR TITLE
[WINDUPRULE-432,433,435,436,437,438] - camel components moved out of camel-core

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/Attacher.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/Attacher.java
@@ -1,0 +1,23 @@
+import javax.activation.DataHandler;
+import javax.mail.util.ByteArrayDataSource;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.camel.Processor;
+
+public class Attacher implements Processor {
+
+    private final String mimetype;
+
+    public AttachmentAttacher(String mimetype) {
+        this.mimetype = mimetype;
+    }
+
+    @Override
+    public void process(Exchange exchange){
+        Message in = exchange.getIn();
+        byte[] file = in.getBody(byte[].class);
+        String fileId = in.getHeader("CamelFileName",String.class);
+        in.addAttachment(fileId, new DataHandler(new     ByteArrayDataSource(file, mimetype)));
+    }
+}

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
@@ -17,6 +17,7 @@ public class MyRouteBuilder extends RouteBuilder {
             .to("mock:result");
 
         from("ref:endpoint1")
+            .marshal().zipDeflater()
             .to("browse:orderReceived")
             .to("controlbus:route?routeId=mainRoute&action=stop&async=true")
             .to("language:simple:classpath:org/apache/camel/component/language/mysimplescript.txt")
@@ -24,7 +25,9 @@ public class MyRouteBuilder extends RouteBuilder {
 
         from("dataset:foo")
             .to("direct-vm:bar");
-            .from("scheduler://foo?delay=60s")
+            .unmarshal().zipDeflater().process(new UnZippedMessageProcessor());
+
+        from("scheduler://foo?delay=60s")
             .to("seda:next")
             .to("stub:smtp://somehost.foo.com?user=windup");
 

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
@@ -4,6 +4,10 @@ import org.apache.camel.builder.RouteBuilder;
  * A Camel Java DSL Router
  */
 public class MyRouteBuilder extends RouteBuilder {
+    rest("/say")
+                .get("/hello").to("direct:hello")
+                .get("/bye").consumes("application/json")
+                .post("/bye");
 
     public void configure() {
         from("direct:xslt-copy-all")
@@ -20,6 +24,11 @@ public class MyRouteBuilder extends RouteBuilder {
 
         from("dataset:foo")
             .to("direct-vm:bar");
+            .from("scheduler://foo?delay=60s")
+            .to("seda:next")
+            .to("stub:smtp://somehost.foo.com?user=windup");
+
+            from("vm:bar?concurrentConsumers=5")
 
         from("scheduler://foo?delay=60s")
             .to("seda:next")

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
@@ -31,12 +31,6 @@ public class MyRouteBuilder extends RouteBuilder {
             .to("seda:next")
             .to("stub:smtp://somehost.foo.com?user=windup");
 
-            from("vm:bar?concurrentConsumers=5")
-
-        from("scheduler://foo?delay=60s")
-            .to("seda:next")
-            .to("stub:smtp://somehost.foo.com?user=windup");
-
         from("vm:bar?concurrentConsumers=5")
             .to("validator:org/apache/camel/component/validator/schema.xsd?headerName=headerToValidate&amp;failOnNullHeader=false");
 

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
@@ -17,7 +17,7 @@ public class MyRouteBuilder extends RouteBuilder {
             .to("mock:result");
 
         from("ref:endpoint1")
-            .marshal().zipDeflater()
+            .marshal().zip()
             .to("browse:orderReceived")
             .to("controlbus:route?routeId=mainRoute&action=stop&async=true")
             .to("language:simple:classpath:org/apache/camel/component/language/mysimplescript.txt")
@@ -25,7 +25,7 @@ public class MyRouteBuilder extends RouteBuilder {
 
         from("dataset:foo")
             .to("direct-vm:bar");
-            .unmarshal().zipDeflater().process(new UnZippedMessageProcessor());
+            .unmarshal().gzip().process(new UnZippedMessageProcessor());
 
         from("scheduler://foo?delay=60s")
             .to("seda:next")

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/RouteBuilder.java
@@ -39,5 +39,10 @@ public class MyRouteBuilder extends RouteBuilder {
 
         from("vm:bar?concurrentConsumers=5")
             .to("validator:org/apache/camel/component/validator/schema.xsd?headerName=headerToValidate&amp;failOnNullHeader=false");
+
+        from("ctivemq:MyQueue").choice()
+            .when().xpath("in:header('foo') = 'bar'").to("activemq:x")
+            .when().xpath("in:body() = '<two/>'").to("activemq:y")
+            .otherwise().to("activemq:MyQueue");
     }
 }

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
@@ -1,6 +1,11 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+<!--        <dataFormats>-->
+<!--            <jaxb id="myJaxb" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
+<!--            <zip id="myzip" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
+<!--            <gzip id="mygzip" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
+<!--        </dataFormats>-->
         <route>
             <from uri="direct:xslt-copy-all"/>
             <to uri="xslt:xslt/copy-all.xsl"/>
@@ -33,3 +38,4 @@
     </camelContext>
 
 </blueprint>
+

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
@@ -35,6 +35,13 @@
             <from uri="vm:bar?concurrentConsumers=5"/>
             <to uri="validator:org/apache/camel/component/validator/schema.xsd?headerName=headerToValidate&amp;failOnNullHeader=false"/>
         </route>
+        <route>
+            <from uri="activemq:MyQueue"/>
+            <filter>
+                <xpath>/foo:person[@name='James']</xpath>
+                <to uri="mqseries:SomeOtherQueue"/>
+            </filter>
+        </route>
     </camelContext>
 
 </blueprint>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
@@ -21,6 +21,7 @@
         </route>
         <route>
             <from uri="scheduler://foo?delay=60s"/>
+            <unmarshal ref="myJaxb"/>
             <to uri="seda:next"/>
             <to uri="controlbus:route?routeId=mainRoute&amp;action=stop&amp;async=true"/>
             <to uri="stub:smtp://somehost.foo.com?user=windup"/>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/blueprint.xml
@@ -1,11 +1,11 @@
 <blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
 
     <camelContext xmlns="http://camel.apache.org/schema/blueprint">
-<!--        <dataFormats>-->
-<!--            <jaxb id="myJaxb" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
-<!--            <zip id="myzip" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
-<!--            <gzip id="mygzip" prettyPrint="true" contextPath="org.apache.camel.example"/>-->
-<!--        </dataFormats>-->
+        <dataFormats>
+            <jaxb id="myJaxb" prettyPrint="true" contextPath="org.apache.camel.example"/>
+            <zip id="myzip" prettyPrint="true" contextPath="org.apache.camel.example"/>
+            <gzip id="mygzip" prettyPrint="true" contextPath="org.apache.camel.example"/>
+        </dataFormats>
         <route>
             <from uri="direct:xslt-copy-all"/>
             <to uri="xslt:xslt/copy-all.xsl"/>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/camel-rest-dsl-blueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/camel-rest-dsl-blueprint.xml
@@ -1,0 +1,27 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+        <rest path="/say">
+            <get uri="/hello">
+                <to uri="direct:hello"/>
+            </get>
+            <get uri="/bye" consumes="application/json">
+                <to uri="direct:bye"/>
+            </get>
+            <post uri="/bye">
+                <to uri="mock:update"/>
+            </post>
+        </rest>
+        <route>
+            <from uri="direct:hello"/>
+            <transform>
+                <constant>Hello World</constant>
+            </transform>
+        </route>
+        <route>
+            <from uri="direct:bye"/>
+            <transform>
+                <constant>Bye World</constant>
+            </transform>
+        </route>
+    </camelContext>
+</blueprint>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/camel-rest-dsl-context.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/camel-rest-dsl-context.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+		http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext xmlns="http://camel.apache.org/schema/spring">
+        <rest path="/say">
+            <get uri="/hello">
+                <to uri="direct:hello"/>
+            </get>
+            <get uri="/bye" consumes="application/json">
+                <to uri="direct:bye"/>
+            </get>
+            <post uri="/bye">
+                <to uri="mock:update"/>
+            </post>
+        </rest>
+        <route>
+            <from uri="direct:hello"/>
+            <transform>
+                <constant>Hello World</constant>
+            </transform>
+        </route>
+        <route>
+            <from uri="direct:bye"/>
+            <transform>
+                <constant>Bye World</constant>
+            </transform>
+        </route>
+    </camelContext>
+</beans>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
@@ -46,5 +46,12 @@
             <from uri="vm:bar?concurrentConsumers=5"/>
 			<to uri="validator:org/apache/camel/component/validator/schema.xsd?headerName=headerToValidate&amp;failOnNullHeader=false"/>
 		</route>
+        <route>
+            <from uri="activemq:MyQueue"/>
+            <filter>
+                <xpath>/foo:person[@name='James']</xpath>
+                <to uri="mqseries:SomeOtherQueue"/>
+            </filter>
+        </route>
     </camelContext>
 </beans>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
@@ -13,6 +13,8 @@
     <camelContext id="test-camel-context" xmlns="http://camel.apache.org/schema/spring" autoStartup="true">
         <dataFormats>
             <jaxb id="myJaxb" prettyPrint="true" contextPath="org.apache.camel.example"/>
+            <zip id="myzip" prettyPrint="true" contextPath="org.apache.camel.example"/>
+            <gzip id="mygzip" prettyPrint="true" contextPath="org.apache.camel.example"/>
         </dataFormats>
         <route>
             <from uri="direct:xslt-copy-all"/>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/context.xml
@@ -11,6 +11,9 @@
     </bean>
 
     <camelContext id="test-camel-context" xmlns="http://camel.apache.org/schema/spring" autoStartup="true">
+        <dataFormats>
+            <jaxb id="myJaxb" prettyPrint="true" contextPath="org.apache.camel.example"/>
+        </dataFormats>
         <route>
             <from uri="direct:xslt-copy-all"/>
             <to uri="xslt:xslt/copy-all.xsl"/>
@@ -26,6 +29,7 @@
         </route>
         <route>
             <from uri="dataset:foo"/>
+            <marshal ref="myJaxb"/>
             <to uri="controlbus:route?routeId=mainRoute&amp;action=stop&amp;async=true"/>
             <to uri="direct-vm:bar"></to>
 
@@ -33,6 +37,7 @@
 		<route>
 			<from uri="scheduler://foo?delay=60s"/>
 			<to uri="seda:next"/>
+            <unmarshal ref="myJaxb"/>
 			<to uri="stub:smtp://somehost.foo.com?user=windup"/>
 		</route>
 		<route>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -10,7 +10,7 @@
             <rule id="xml-moved-components-00000-test">
                 <when>
                     <not>
-                        <iterable-filter size="53">
+                        <iterable-filter size="47">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -22,7 +22,7 @@
             <rule id="xml-moved-components-00001-test">
                 <when>
                     <not>
-                        <iterable-filter size="53">
+                        <iterable-filter size="47">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -34,7 +34,7 @@
             <rule id="xml-moved-components-00002-test">
                 <when>
                     <not>
-                        <iterable-filter size="53">
+                        <iterable-filter size="47">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -42,7 +42,7 @@
                 <perform>
                     <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
                 </perform>
-git            </rule>
+            </rule>
             <rule id="xml-moved-components-00003-test">
                 <when>
                     <not>
@@ -83,7 +83,7 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="camel-attachments` required for using rest DSL.*"/>
+                            <hint-exists message="`camel-attachments` required for using rest DSL.*"/>
                         </iterable-filter>
                     </not>
                 </when>
@@ -95,7 +95,7 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="2">
-                            <hint-exists message="camel-dataformat` dependency required.*"/>
+                            <hint-exists message="`camel-dataformat` dependency required.*"/>
                         </iterable-filter>
                     </not>
                 </when>
@@ -107,7 +107,7 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="2">
-                            <hint-exists message="camel-dataformat` dependency required.*"/>
+                            <hint-exists message="`camel-dataformat` dependency required.*"/>
                         </iterable-filter>
                     </not>
                 </when>
@@ -119,7 +119,7 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="2">
-                            <hint-exists message="camel-zip-deflater` dependency required.*"/>
+                            <hint-exists message="`camel-zip-deflater` dependency required.*"/>
                         </iterable-filter>
                     </not>
                 </when>
@@ -131,7 +131,7 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="2">
-                            <hint-exists message="camel-zip-deflater` dependency required.*"/>
+                            <hint-exists message="`camel-zip-deflater` dependency required.*"/>
                         </iterable-filter>
                     </not>
                 </when>
@@ -143,12 +143,12 @@ git            </rule>
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="camel-xpath` dependency required.*"/>
+                            <hint-exists message="`camel-xpath` dependency required.*"/>
                         </iterable-filter>
                     </not>
                 </when>
                 <perform>
-                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
+                    <fail message="[xml-moved-components] `camel-zip-deflater` dependency moved hint was not found!"/>
                 </perform>
             </rule>
         </rules>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -79,6 +79,18 @@
                     <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
                 </perform>
             </rule>
+            <rule id="xml-moved-components-00006-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="camel-attachments` required for using rest DSL.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -115,6 +115,30 @@
                     <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
                 </perform>
             </rule>
+            <rule id="xml-moved-components-00009-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="camel-zip-deflater` dependency required.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00010-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="camel-zip-deflater` dependency required.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -139,6 +139,18 @@
                     <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
                 </perform>
             </rule>
+            <rule id="xml-moved-components-00011-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="camel-xpath` dependency required.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -10,7 +10,7 @@
             <rule id="xml-moved-components-00000-test">
                 <when>
                     <not>
-                        <iterable-filter size="50">
+                        <iterable-filter size="53">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -22,7 +22,7 @@
             <rule id="xml-moved-components-00001-test">
                 <when>
                     <not>
-                        <iterable-filter size="50">
+                        <iterable-filter size="53">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -34,7 +34,7 @@
             <rule id="xml-moved-components-00002-test">
                 <when>
                     <not>
-                        <iterable-filter size="50">
+                        <iterable-filter size="53">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
@@ -42,7 +42,7 @@
                 <perform>
                     <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
                 </perform>
-            </rule>
+git            </rule>
             <rule id="xml-moved-components-00003-test">
                 <when>
                     <not>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -88,7 +88,7 @@
                     </not>
                 </when>
                 <perform>
-                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                    <fail message="[xml-moved-components] camel-attachments dependency moved hint was not found!"/>
                 </perform>
             </rule>
             <rule id="xml-moved-components-00007-test">
@@ -112,7 +112,7 @@
                     </not>
                 </when>
                 <perform>
-                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                    <fail message="[xml-moved-components] camel-dataformat dependency moved hint was not found!"/>
                 </perform>
             </rule>
             <rule id="xml-moved-components-00009-test">
@@ -148,7 +148,7 @@
                     </not>
                 </when>
                 <perform>
-                    <fail message="[xml-moved-components] `camel-zip-deflater` dependency moved hint was not found!"/>
+                    <fail message="[xml-moved-components] `camel-xpath` dependency moved hint was not found!"/>
                 </perform>
             </rule>
         </rules>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -91,6 +91,30 @@
                     <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
                 </perform>
             </rule>
+            <rule id="xml-moved-components-00007-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="camel-dataformat` dependency required.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-dataformat dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00008-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="camel-dataformat` dependency required.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0"?>
 <ruletest id="xml-moved-components-tests"
-          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
-          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+        xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
     <testDataPath>data/xml-moved-components</testDataPath>
     <rulePath>../xml-moved-components.windup.xml</rulePath>
     <ruleset>
@@ -9,37 +10,73 @@
             <rule id="xml-moved-components-00000-test">
                 <when>
                     <not>
-                        <iterable-filter size="45">
-                            <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] Camel dependency moved hint was not found!" />
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00001-test">
-                <when>
-                    <not>
-                        <iterable-filter size="45">
-                            <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] Camel dependency moved hint was not found!" />
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00002-test">
-                <when>
-                    <not>
-                        <iterable-filter size="45">
+                        <iterable-filter size="50">
                             <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
                         </iterable-filter>
                     </not>
                 </when>
                 <perform>
                     <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00001-test">
+                <when>
+                    <not>
+                        <iterable-filter size="50">
+                            <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00002-test">
+                <when>
+                    <not>
+                        <iterable-filter size="50">
+                            <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00003-test">
+                <when>
+                    <not>
+                        <iterable-filter size="3">
+                            <hint-exists message="`camel-rest` required for using rest DSL.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00004-test">
+                <when>
+                    <not>
+                        <iterable-filter size="3">
+                            <hint-exists message="`camel-rest` required for using rest DSL.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
+                </perform>
+            </rule>
+            <rule id="xml-moved-components-00005-test">
+                <when>
+                    <not>
+                        <iterable-filter size="3">
+                            <hint-exists message="`camel-rest` required for using rest DSL.*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
                 </perform>
             </rule>
         </rules>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -37,7 +37,7 @@
             </perform>
             <where param="component">
                 <matches
-                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
             </where>
         </rule>
         <rule id="xml-moved-components-00001">
@@ -64,7 +64,7 @@
             </perform>
             <where param="component">
                 <matches
-                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
             </where>
         </rule>
         <rule id="xml-moved-components-00002">
@@ -89,9 +89,10 @@
             </perform>
             <where param="component">
                 <matches
-                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
             </where>
         </rule>
+
         <rule id="xml-moved-components-00003">
             <when>
                 <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
@@ -164,6 +165,7 @@
         </rule>
         <rule id="xml-moved-components-00006">
             <when>
+                <!--               <filecontent pattern="'xslt:'" filename="{*}.java"/>-->
                 <filecontent pattern=".addAttachment{*}" filename="{*}.java"/>
                 <xmlfile as="dependencies-block" in="pom.xml"
                         matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-attachments'])=0]">
@@ -327,35 +329,6 @@
                 </iteration>
             </perform>
         </rule>
-<!--        <rule id="xml-moved-components-00012">-->
-<!--            <when>-->
-<!--                <xmlfile as="dependencies-block" in="pom.xml"-->
-<!--                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">-->
-<!--                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>-->
-<!--                </xmlfile>-->
-
-<!--                <or>-->
-<!--                    <xmlfile matches="//*[count(b:xpath) >0]">-->
-<!--                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>-->
-<!--                    </xmlfile>-->
-<!--                    <xmlfile matches="//*[count(c:xpath) > 0]">-->
-<!--                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>-->
-<!--                    </xmlfile>-->
-<!--                </or>-->
-<!--            </when>-->
-<!--            <perform>-->
-<!--                <iteration over="dependencies-block">-->
-<!--                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">-->
-<!--                        <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact-->
-<!--                            org.apache.camel:camel-dataformat that has to be-->
-<!--                            added as a dependency to your project pom.xml file-->
-<!--                        </message>-->
-<!--                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"-->
-<!--                                title="Camel 3 - Migration Guide"/>-->
-<!--                    </hint>-->
-<!--                </iteration>-->
-<!--            </perform>-->
-<!--        </rule>-->
     </rules>
 </ruleset>
 

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -89,6 +89,153 @@
                         <matches pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
                     </where>
                 </rule>
+        <rule id="xml-moved-components-00000">
+            <when>
+                <xmlfile matches="//*/c:route/*/@uri[windup:matches(self::node(), '{component}:{*}')]">
+                    <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                </xmlfile>
+                <xmlfile as="dependencies-block"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
+                        in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
+                            `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                                title="Camel 3 - Migration Guide: Modularization of camel-core"/>
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="component">
+                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+            </where>
+        </rule>
+        <rule id="xml-moved-components-00001">
+            <when>
+                <xmlfile matches="//*/b:route/*/@uri[windup:matches(self::node(), '{component}:{*}')]">
+                    <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
+                </xmlfile>
+                <xmlfile as="dependencies-block"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
+                        in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
+                            `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                                title="Camel 3 - Migration Guide: Modularization of camel-core"/>
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="component">
+                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+            </where>
+        </rule>
+        <rule id="xml-moved-components-00002">
+            <when>
+                <filecontent pattern="(&quot;{component}:" filename="{*}.java"/>
+                <xmlfile as="dependencies-block"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
+                        in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
+                            `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                                title="Camel 3 - Migration Guide: Modularization of camel-core"/>
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="component">
+                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+            </where>
+        </rule>
+
+        <rule id="xml-moved-components-00003">
+            <when>
+                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
+                    <location>INHERITANCE</location>
+                </javaclass>
+                <filecontent pattern="rest({*})" from="routeBuilders"/>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-rest'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-rest` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-rest` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-rest that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="xml-moved-components-00004">
+            <when>
+                <xmlfile matches="//*[(count(c:rest)+count(c:get)+count(c:post)+count(c:put)+count(c:delete))>0 ]">
+                    <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                </xmlfile>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-rest'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-rest` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-rest` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-rest that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="xml-moved-components-00005">
+            <when>
+                <xmlfile matches="//*[(count(b:rest)+count(b:get)+count(b:post)+count(b:put)+count(b:delete))>0 ]">
+                    <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
+                </xmlfile>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-rest'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-rest` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-rest` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-rest that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
     </rules>
 </ruleset>
 

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -296,6 +296,66 @@
                 </iteration>
             </perform>
         </rule>
+        <rule id="xml-moved-components-00011">
+            <when>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-xpath'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
+                    <location>INHERITANCE</location>
+                </javaclass>
+                <or>
+                    <filecontent pattern=".xpath({*})" from="routeBuilders"/>
+                    <xmlfile matches="//*[count(b:xpath) >0]">
+                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
+                    </xmlfile>
+                    <xmlfile matches="//*[count(c:xpath) > 0]">
+                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                    </xmlfile>
+                </or>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-dataformat that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+<!--        <rule id="xml-moved-components-00012">-->
+<!--            <when>-->
+<!--                <xmlfile as="dependencies-block" in="pom.xml"-->
+<!--                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">-->
+<!--                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>-->
+<!--                </xmlfile>-->
+
+<!--                <or>-->
+<!--                    <xmlfile matches="//*[count(b:xpath) >0]">-->
+<!--                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>-->
+<!--                    </xmlfile>-->
+<!--                    <xmlfile matches="//*[count(c:xpath) > 0]">-->
+<!--                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>-->
+<!--                    </xmlfile>-->
+<!--                </or>-->
+<!--            </when>-->
+<!--            <perform>-->
+<!--                <iteration over="dependencies-block">-->
+<!--                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">-->
+<!--                        <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact-->
+<!--                            org.apache.camel:camel-dataformat that has to be-->
+<!--                            added as a dependency to your project pom.xml file-->
+<!--                        </message>-->
+<!--                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"-->
+<!--                                title="Camel 3 - Migration Guide"/>-->
+<!--                    </hint>-->
+<!--                </iteration>-->
+<!--            </perform>-->
+<!--        </rule>-->
     </rules>
 </ruleset>
 

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -261,7 +261,7 @@
                 <iteration over="dependencies-block">
                     <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
                         <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
-                            org.apache.camel:camel-dataformat that has to be added as a dependency to your project pom.xml file
+                            `org.apache.camel:camel-zip-deflater` that has to be added as a dependency to your project pom.xml file
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
                                 title="Camel 3 - Migration Guide"/>
@@ -289,7 +289,7 @@
                 <iteration over="dependencies-block">
                     <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
                         <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
-                            org.apache.camel:camel-dataformat that has to be
+                            `org.apache.camel:camel-zip-deflater` that has to be
                             added as a dependency to your project pom.xml file
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
@@ -321,7 +321,7 @@
                 <iteration over="dependencies-block">
                     <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">
                         <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact
-                            org.apache.camel:camel-dataformat that has to be added as a dependency to your project pom.xml file
+                            `org.apache.camel:camel-xpath` that has to be added as a dependency to your project pom.xml file
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
                                 title="Camel 3 - Migration Guide"/>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -236,6 +236,28 @@
                 </iteration>
             </perform>
         </rule>
+        <rule id="xml-moved-components-00006">
+            <when>
+<!--               <filecontent pattern="'xslt:'" filename="{*}.java"/>-->
+                <filecontent pattern=".addAttachment{*}" filename="{*}.java"/>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-attachments'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-attachments` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-attachments` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-rest that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
     </rules>
 </ruleset>
 

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -233,10 +233,64 @@
                 <iteration over="dependencies-block">
                     <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
                         <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-dataformat that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="xml-moved-components-00009">
+            <when>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-zip-deflater'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
+                    <location>INHERITANCE</location>
+                </javaclass>
+                <or>
+                    <filecontent pattern=".zip({*})" from="routeBuilders"/>
+                    <filecontent pattern=".gzip({*})" from="routeBuilders"/>
+                </or>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-dataformat that has to be added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="xml-moved-components-00010">
+            <when>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+
+                <or>
+                    <xmlfile matches="//*[(count(b:zip)+count(b:gzip)) >0]">
+                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
+                    </xmlfile>
+                    <xmlfile matches="//*[(count(c:gzip)+count(c:zip)) > 0]">
+                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                    </xmlfile>
+                </or>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
                             org.apache.camel:camel-dataformat that has to be
                             added as a dependency to your project pom.xml file
                         </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
                                 title="Camel 3 - Migration Guide"/>
                     </hint>
                 </iteration>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -13,82 +13,6 @@
         <targetTechnology id="camel" versionRange="[3,)"/>
     </metadata>
     <rules>
-                <rule id="xml-moved-components-00000">
-                    <when>
-                        <xmlfile matches="//*/c:route/*/@uri[windup:matches(self::node(), '{component}:{*}')]">
-                            <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
-                        </xmlfile>
-                        <xmlfile as="dependencies-block"
-                                matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
-                                in="pom.xml">
-                            <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                        </xmlfile>
-                    </when>
-                    <perform>
-                        <iteration over="dependencies-block">
-                            <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
-                                <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
-                                    `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
-                                </message>
-                                <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
-                                        title="Camel 3 - Migration Guide: Modularization of camel-core"/>
-                            </hint>
-                        </iteration>
-                    </perform>
-                    <where param="component">
-                        <matches pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
-                    </where>
-                </rule>
-                <rule id="xml-moved-components-00001">
-                    <when>
-                        <xmlfile matches="//*/b:route/*/@uri[windup:matches(self::node(), '{component}:{*}')]">
-                            <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
-                        </xmlfile>
-                        <xmlfile as="dependencies-block"
-                                matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
-                                in="pom.xml">
-                            <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                        </xmlfile>
-                    </when>
-                    <perform>
-                        <iteration over="dependencies-block">
-                            <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
-                                <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
-                                    `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
-                                </message>
-                                <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
-                                        title="Camel 3 - Migration Guide: Modularization of camel-core"/>
-                            </hint>
-                        </iteration>
-                    </perform>
-                    <where param="component">
-                        <matches pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
-                    </where>
-                </rule>
-                <rule id="xml-moved-components-00002">
-                    <when>
-                        <filecontent pattern="(&quot;{component}:" filename="{*}.java"/>
-                        <xmlfile as="dependencies-block"
-                                matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{component}')])=0]"
-                                in="pom.xml">
-                            <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                        </xmlfile>
-                    </when>
-                    <perform>
-                        <iteration over="dependencies-block">
-                            <hint title="`camel-{component}` has been moved" effort="1" category-id="mandatory">
-                                <message>`camel-{component}` component has been moved from `camel-core` to separate artifact
-                                    `org.apache.camel:camel-{component}` that has to be added as a dependency to your project pom.xml file
-                                </message>
-                                <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
-                                        title="Camel 3 - Migration Guide: Modularization of camel-core"/>
-                            </hint>
-                        </iteration>
-                    </perform>
-                    <where param="component">
-                        <matches pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
-                    </where>
-                </rule>
         <rule id="xml-moved-components-00000">
             <when>
                 <xmlfile matches="//*/c:route/*/@uri[windup:matches(self::node(), '{component}:{*}')]">
@@ -112,7 +36,8 @@
                 </iteration>
             </perform>
             <where param="component">
-                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+                <matches
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
             </where>
         </rule>
         <rule id="xml-moved-components-00001">
@@ -138,7 +63,8 @@
                 </iteration>
             </perform>
             <where param="component">
-                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+                <matches
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
             </where>
         </rule>
         <rule id="xml-moved-components-00002">
@@ -162,10 +88,10 @@
                 </iteration>
             </perform>
             <where param="component">
-                <matches pattern="(bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm)"/>
+                <matches
+                        pattern="(language|bean|direct|xslt|browse|dataset|direct-vm|file|log|mock|ref|saga|scheduler|seda|stub|timer|validator|vm|controlbus)"/>
             </where>
         </rule>
-
         <rule id="xml-moved-components-00003">
             <when>
                 <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
@@ -238,7 +164,6 @@
         </rule>
         <rule id="xml-moved-components-00006">
             <when>
-<!--               <filecontent pattern="'xslt:'" filename="{*}.java"/>-->
                 <filecontent pattern=".addAttachment{*}" filename="{*}.java"/>
                 <xmlfile as="dependencies-block" in="pom.xml"
                         matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-attachments'])=0]">
@@ -250,6 +175,65 @@
                     <hint title="`camel-attachments` component has been moved" effort="1" category-id="mandatory">
                         <message>`camel-attachments` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
                             org.apache.camel:camel-rest that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+
+        <rule id="xml-moved-components-00007">
+            <when>
+
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
+                    <location>INHERITANCE</location>
+                </javaclass>
+                <or>
+                    <filecontent pattern=".marshal({*})" from="routeBuilders"/>
+                    <filecontent pattern="unmarshal({*})" from="routeBuilders"/>
+                </or>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-dataformat that has to be
+                            added as a dependency to your project pom.xml file
+                        </message>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
+                                title="Camel 3 - Migration Guide"/>
+                    </hint>
+                </iteration>
+            </perform>
+        </rule>
+        <rule id="xml-moved-components-00008">
+            <when>
+                <xmlfile as="dependencies-block" in="pom.xml"
+                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+
+                <or>
+                    <xmlfile matches="//*[(count(b:marshal)+count(b:unmarshal)+count(b:dataformats)) >0]">
+                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
+                    </xmlfile>
+                    <xmlfile matches="//*[(count(c:marshal)+count(c:unmarshal)+ count(c:dataformats)) > 0]">
+                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                    </xmlfile>
+
+                </or>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
+                        <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
+                            org.apache.camel:camel-dataformat that has to be
                             added as a dependency to your project pom.xml file
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-432 - `camel-zip-deflater` 
https://issues.redhat.com/browse/WINDUPRULE-433  `camel-attachements` 
https://issues.redhat.com/browse/WINDUPRULE-435  `camel-dataformat` 
https://issues.redhat.com/browse/WINDUPRULE-436  `camel-language` 
https://issues.redhat.com/browse/WINDUPRULE-437  `camel-rest` 
https://issues.redhat.com/browse/WINDUPRULE-438 `camel-xpath` 