### PR TITLE
WINDUPRULE-415 camel-mongodb3 has been renamed

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-renamed-components/pom.xml
@@ -19,6 +19,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-zookeeper-starter</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-mongodb3</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-renamed-components.windup.test.xml
@@ -42,6 +42,18 @@
                     <fail message="[xml-renamed-components] 'camel-zookeeper-starter' dependency moved hint was not found!" />
                 </perform>
             </rule>
+            <rule id="xml-renamed-components-00003-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="`org.apache.camel:camel-mongodb3` artifact has been renamed to `org.apache.camel:camel-mongodb`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-renamed-components] 'camel-mongodb3' dependency moved hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -62,6 +62,23 @@
                 <matches pattern="([a-zA-Z0-9]|-)*" />
             </where>
         </rule>
+        <rule id="xml-renamed-components-00003">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-mongodb3" />
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-mongodb3` artifact has been renamed to `org.apache.camel:camel-mongodb`" effort="1" category-id="mandatory" >
+                    <message>`org.apache.camel:camel-mongodb3` artifact has been renamed to `org.apache.camel:camel-mongodb`. It’s corresponding component package was renamed from `org.apache.camel.component.mongodb3` to `org.apache.camel.component.mongodb`. The supported scheme is now `mongodb`.</message>
+                    <link title="Camel 3 - Renamed Components" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_renamed_components" />
+                    <quickfix type="REPLACE" name="camel-mongodb3-replace">
+                        <replacement>camel-mongodb</replacement>
+                        <search>camel-mongodb3</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>
 

--- a/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-renamed-components.windup.xml
@@ -69,7 +69,7 @@
                 </project>
             </when>
             <perform>
-                <hint title="`org.apache.camel:camel-mongodb3` artifact has been renamed to `org.apache.camel:camel-mongodb`" effort="1" category-id="mandatory" >
+                <hint title="`org.apache.camel:camel-mongodb3` artifact has been renamed" effort="1" category-id="mandatory" >
                     <message>`org.apache.camel:camel-mongodb3` artifact has been renamed to `org.apache.camel:camel-mongodb`. It’s corresponding component package was renamed from `org.apache.camel.component.mongodb3` to `org.apache.camel.component.mongodb`. The supported scheme is now `mongodb`.</message>
                     <link title="Camel 3 - Renamed Components" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_renamed_components" />
                     <quickfix type="REPLACE" name="camel-mongodb3-replace">
@@ -81,4 +81,3 @@
         </rule>
     </rules>
 </ruleset>
-


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-415

Tested executing $ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-renamed-components clean surefire-report:report

Thanks !