### PR TITLE
WINDUPRULE-413 Camel 3 org.apache.camel.language.LanguageAnnotation h…

### DIFF
--- a/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
@@ -418,5 +418,22 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="java-generic-information-00022">
+            <when>
+                <javaclass references="org.apache.camel.language.LanguageAnnotation">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel.language.LanguageAnnotation` has been moved" effort="1" category-id="mandatory">
+                    <message>The class `org.apache.camel.language.LanguageAnnotation` has been moved to `org.apache.camel.support.language.LanguageAnnotation`. It has been moved out of `org.apache.camel:camel-core` and into `org.apache.camel:camel-support`.</message>
+                    <link title="Camel 3 - Migration Guide: Migrating custom languages" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_migrating_custom_languages" />
+                    <quickfix type="REPLACE" name="LanguageAnnotation-replace">
+                        <replacement>org.apache.camel.support.language.LanguageAnnotation</replacement>
+                        <search>org.apache.camel.language.LanguageAnnotation</search>
+                    </quickfix>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/MyLanguage.java
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/MyLanguage.java
@@ -1,0 +1,23 @@
+package camelinaction;
+
+package org.apache.camel.language.simple;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.apache.camel.language.LanguageAnnotation;
+
+/**
+ * Used to inject a simple expression into a field, property, method or parameter when using
+ * <a href="http://camel.apache.org/bean-integration.html">Bean Integration</a>.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
+@LanguageAnnotation(language = "simple")
+public @interface Simple {
+    String value();
+}

--- a/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
@@ -269,6 +269,18 @@
                     <fail message="[java-generic-information] Exception moved hint was not found!" />
                 </perform>
             </rule>
+            <rule id="java-generic-information-00022-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The class `org.apache.camel.language.LanguageAnnotation` has been moved to `org.apache.camel.support.language.LanguageAnnotation`*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-generic-information] 'LanguageAnnotation' moved hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
…as been moved to org.apache.camel.support.language.LanguageAnnotation

https://issues.redhat.com/browse/WINDUPRULE-413

Tests can be run using the command: `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-generic-information clean surefire-report:report -nsu`

Thanks !