### PR TITLE
WINDUPRULE-470: Camel 3 org.apache.camel.FallbackConverter has been r…

### DIFF
--- a/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
@@ -582,5 +582,19 @@
                 <matches pattern="(FileIdempotentRepository|MemoryIdempotentRepository)" />
             </where>
         </rule>
+        <rule id="java-generic-information-00030">
+            <when>
+                <javaclass references="org.apache.camel.FallbackConverter">
+                    <location>IMPORT</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="Annotation `org.apache.camel.FallbackConverter` has been removed" effort="1" category-id="mandatory">
+                    <message>Annotation `org.apache.camel.FallbackConverter` has been removed. You should use `@org.apache.camel.Converter(fallback = true)` from `org.apache.camel:camel-api` instead. You can also set `@org.apache.camel.Converter(generateLoader = true)` on the converter class to allow Camel to generate source code for loading type converters in a faster way.</message>
+                    <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_fallback_type_converters"
+                          title="Camel 3 - Migration Guide: Fallback Type Converters"/>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/JettyConverter.java
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/JettyConverter.java
@@ -1,0 +1,39 @@
+
+package org.apache.camel.component.jetty;
+
+import org.apache.camel.Converter;
+import org.apache.camel.Exchange;
+import org.apache.camel.FallbackConverter;
+import org.apache.camel.spi.TypeConverterRegistry;
+import org.eclipse.jetty.server.Request;
+import org.eclipse.jetty.server.Response;
+
+/**
+ * @version
+ */
+@Converter
+public final class JettyConverter {
+
+    private JettyConverter() {
+        //Helper class
+    }
+
+    @Converter
+    public static String toString(Response response) {
+        return response.toString();
+    }
+
+    @FallbackConverter
+    @SuppressWarnings("unchecked")
+    public static <T> T convertTo(Class<T> type, Exchange exchange, Object value, TypeConverterRegistry registry) {
+        if (value != null) {
+            // should not try to convert Request as its not possible
+            if (Request.class.isAssignableFrom(value.getClass())) {
+                return (T) Void.TYPE;
+            }
+        }
+
+        return null;
+    }
+
+}

--- a/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
@@ -365,6 +365,18 @@
                     <fail message="[java-generic-information] Idempotent repositories moved hint was not found!" />
                 </perform>
             </rule>
+            <rule id="java-generic-information-00030-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="Annotation `org.apache.camel.FallbackConverter` has been removed*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-generic-information] `org.apache.camel.FallbackConverter` removed hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
…emoved

https://issues.redhat.com/browse/WINDUPRULE-470

run tests with `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-generic-information clean surefire-report:report`

Thanks !