### PR TITLE
WINDUPRULE-425 camel-aws has been split up into multiple components

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsBlueprintTest.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsBlueprintTest.xml
@@ -1,0 +1,11 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+    <camelContext xmlns="http://camel.apache.org/schema/blueprint">
+        <route>
+            <from uri="direct:start"/>
+            <to uri="aws-sdb://TestDomain?amazonSDBClient=#amazonSDBClient&amp;operation=GetAttributes"/>
+        </route>
+    </camelContext>
+
+    <bean id="amazonSDBClient" class="org.apache.camel.component.aws.sdb.AmazonSDBClientMock"/>
+</blueprint>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsSpringNegativeTest.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsSpringNegativeTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="direct:start"/>
+            <to uri="aws-cw://TestDomain?amazonSDBClient=#amazonSDBClient&amp;operation=GetAttributes"/>
+        </route>
+    </camelContext>
+
+    <bean id="amazonSDBClient" class="org.apache.camel.component.aws.sdb.AmazonSDBClientMock"/>
+</beans>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsSpringTest.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/AwsSpringTest.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="
+    http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+    http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd">
+
+    <camelContext id="camel" xmlns="http://camel.apache.org/schema/spring">
+        <route>
+            <from uri="direct:start"/>
+            <to uri="aws-sdb://TestDomain?amazonSDBClient=#amazonSDBClient&amp;operation=GetAttributes"/>
+        </route>
+    </camelContext>
+
+    <bean id="amazonSDBClient" class="org.apache.camel.component.aws.sdb.AmazonSDBClientMock"/>
+</beans>

--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/CwComponentTest.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/CwComponentTest.java
@@ -1,0 +1,54 @@
+package camel2.org.apache.camel.component.aws2.cw;
+
+import java.time.Instant;
+
+import org.apache.camel.BindToRegistry;
+import org.apache.camel.EndpointInject;
+import org.apache.camel.Exchange;
+import org.apache.camel.Processor;
+import org.apache.camel.builder.RouteBuilder;
+import org.apache.camel.component.mock.MockEndpoint;
+import org.apache.camel.test.junit5.CamelTestSupport;
+import org.junit.jupiter.api.Test;
+import software.amazon.awssdk.services.cloudwatch.CloudWatchClient;
+import software.amazon.awssdk.services.cloudwatch.model.StandardUnit;
+
+public class CwComponentTest extends CamelTestSupport {
+
+    @BindToRegistry("now")
+    private static final Instant NOW = Instant.now();
+
+    private static final Instant LATER = Instant.ofEpochMilli(NOW.getNano() + 1);
+
+    @BindToRegistry("amazonCwClient")
+    private CloudWatchClient cloudWatchClient = new CloudWatchClientMock();
+
+    @EndpointInject("mock:result")
+    private MockEndpoint mock;
+
+    @Test
+    public void sendMetricFromHeaderValues() throws Exception {
+        mock.expectedMessageCount(1);
+        Exchange exchange = template.request("direct:start", new Processor() {
+            public void process(Exchange exchange) throws Exception {
+                exchange.getIn().setHeader(Cw2Constants.METRIC_NAMESPACE, "camel.apache.org/overriden");
+                exchange.getIn().setHeader(Cw2Constants.METRIC_NAME, "OverridenMetric");
+                exchange.getIn().setHeader(Cw2Constants.METRIC_VALUE, Double.valueOf(3));
+                exchange.getIn().setHeader(Cw2Constants.METRIC_UNIT, StandardUnit.BYTES.toString());
+                exchange.getIn().setHeader(Cw2Constants.METRIC_TIMESTAMP, LATER);
+            }
+        });
+
+        assertMockEndpointsSatisfied();
+    }
+
+    @Override
+    protected RouteBuilder createRouteBuilder() throws Exception {
+        return new RouteBuilder() {
+            @Override
+            public void configure() throws Exception {
+                from("direct:start").to("aws2-cw://camel.apache.org/test?amazonCwClient=#amazonCwClient&name=testMetric&unit=BYTES&timestamp=#now").to("mock:result");
+            }
+        };
+    }
+}

--- a/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-removed-components/pom.xml
@@ -23,6 +23,10 @@
             <groupId>org.apache.camel</groupId>
             <artifactId>camel-boon</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-aws</artifactId>
+        </dependency>
     </dependencies>
 
 </project>

--- a/rules-reviewed/camel3/camel2/tests/xml-removed-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-removed-components.windup.test.xml
@@ -66,6 +66,54 @@
                     <fail message="[xml-removed-components] 'camel-twitter-streaming' dependency removed hint was not found!" />
                 </perform>
             </rule>
+            <rule id="xml-removed-components-00005-test">
+                <when>
+                    <not>
+                        <iterable-filter size="4">
+                            <hint-exists message="`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-removed-components] 'camel-aws' dependency removed hint was not found!" />
+                </perform>
+            </rule>
+            <rule id="xml-removed-components-00006-test">
+                <when>
+                    <not>
+                        <iterable-filter size="4">
+                            <hint-exists message="`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-removed-components] 'camel-aws' dependency removed hint was not found!" />
+                </perform>
+            </rule>
+            <rule id="xml-removed-components-00007-test">
+                <when>
+                    <not>
+                        <iterable-filter size="4">
+                            <hint-exists message="`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-removed-components] 'camel-aws' dependency removed hint was not found!" />
+                </perform>
+            </rule>
+            <rule id="xml-removed-components-00008-test">
+                <when>
+                    <not>
+                        <iterable-filter size="4">
+                            <hint-exists message="`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-removed-components] 'camel-aws' dependency removed hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>

--- a/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
@@ -86,6 +86,82 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="xml-removed-components-00005">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-aws" />
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-aws` artifact has been split up into multiple components" effort="1" category-id="mandatory" >
+                    <message>`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components. So you’ll have to explicitly add the dependencies for these components. Please remove `org.apache.camel:camel-aws`. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.</message>
+                    <link title="Camel 3 - AWS" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_aws" />
+                </hint>
+            </perform>
+        </rule>
+        <rule id="xml-removed-components-00006">
+            <when>
+                <xmlfile as="dependencies-block" matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{aws-component}')])=0]" in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <filecontent pattern="{from|to}(&quot;{aws-component}:" filename="{*}.java"/>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`org.apache.camel:camel-aws` artifact has been split up into multiple components" effort="1" category-id="mandatory" >
+                        <message>`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components. So you’ll have to explicitly add the dependencies for these components. Please add `org.apache.camel:{aws-component}` to your `pom.xml` file. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.</message>
+                        <link title="Camel 3 - AWS" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_aws" />
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="aws-component">
+                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+            </where>
+        </rule>
+        <rule id="xml-removed-components-00007">
+            <when>
+                <xmlfile as="dependencies-block" matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{aws-component}')])=0]" in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <!-- Spring XML -->
+                <xmlfile matches="//*/c:route/*/@uri[windup:matches(self::node(), '{aws-component}:{*}')]">
+                    <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`org.apache.camel:camel-aws` artifact has been split up into multiple components" effort="1" category-id="mandatory" >
+                        <message>`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components. So you’ll have to explicitly add the dependencies for these components. Please add `org.apache.camel:{aws-component}` to your `pom.xml` file. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.</message>
+                        <link title="Camel 3 - AWS" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_aws" />
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="aws-component">
+                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+            </where>
+        </rule>
+        <rule id="xml-removed-components-00008">
+            <when>
+                <xmlfile as="dependencies-block" matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[windup:matches(text(), 'camel-{aws-component}')])=0]" in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+                <!-- Blueprint XML -->
+                <xmlfile matches="//*/c:route/*/@uri[windup:matches(self::node(), '{aws-component}:{*}')]">
+                    <namespace prefix="c" uri="http://camel.apache.org/schema/blueprint"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <iteration over="dependencies-block">
+                    <hint title="`org.apache.camel:camel-aws` artifact has been split up into multiple components" effort="1" category-id="mandatory" >
+                        <message>`org.apache.camel:camel-aws` artifact has been removed and split up into multiple components. So you’ll have to explicitly add the dependencies for the AWS components. Please add `org.apache.camel:{aws-component}` to your `pom.xml` file. From the OSGi perspective, there is still a `camel-aws` Karaf feature, which includes all the components features.</message>
+                        <link title="Camel 3 - AWS" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_aws" />
+                    </hint>
+                </iteration>
+            </perform>
+            <where param="aws-component">
+                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+            </where>
+        </rule>
     </rules>
 </ruleset>
 


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-425

Thanks !

To run tests: `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-removed-components clean surefire-report:report`