### PR TITLE
WINDUPRULE-457 camel-fhir default FHIR version has changed from DSTU3…

### DIFF
--- a/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
@@ -648,5 +648,18 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="java-generic-information-00033">
+            <when>
+                <project>
+                    <artifact groupId="org.apache.camel" artifactId="camel-fhir" toVersion="2"/>
+                </project>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel:camel-fhir` default FHIR specification has changed from DSTU3 to R4" effort="0" category-id="information" >
+                    <message>The default FHIR specification in the `org.apache.camel:camel-fhir` artifact has changed from DSTU3 to R4. Therefore if DSTU3 is desired it has to be explicitly set.</message>
+                    <link title="Camel 3 - Migration Guide: FHIR" href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_fhir" />
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/pom.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/pom.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>org.sample</groupId>
+    <artifactId>sample-project</artifactId>
+    <version>0.0.1</version>
+    <name>Sample Project</name>
+    <properties>
+        <version.camel2>2.24.3</version.camel2>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.apache.camel</groupId>
+            <artifactId>camel-fhir</artifactId>
+            <version>${version.camel2}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
@@ -401,6 +401,18 @@
                     <fail message="[java-generic-information] `org.apache.camel.CamelContext` `getProperties` removed hint was not found!" />
                 </perform>
             </rule>
+            <rule id="java-generic-information-00033-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The default FHIR specification*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[xml-major-upgrade-components] 'camel-fhir' dependency upgrade hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
… to R4. If DSTU3 is desired it has to be explicitly set

https://issues.redhat.com/browse/WINDUPRULE-457

To run tests: `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-generic-information clean surefire-report:report`

Thanks !