### PR TITLE
WINDUPRULE-460 getProperties and setProperty methods have been remove…

### DIFF
--- a/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
@@ -622,5 +622,31 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="java-generic-information-00032">
+            <when>
+                <or>
+                    <!-- Spring XML -->
+                    <xmlfile matches="//c:camelContext/c:properties">
+                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
+                    </xmlfile>
+                    <!-- Blueprint XML -->
+                    <xmlfile matches="//c:camelContext/c:properties">
+                        <namespace prefix="c" uri="http://camel.apache.org/schema/blueprint"/>
+                    </xmlfile>
+                    <!-- Java-->
+                    <javaclass references="org.apache.camel.CamelContext.{get|set}Propert{y|ies}({*})" >
+                        <location>METHOD_CALL</location>
+                    </javaclass>
+                </or>
+            </when>
+            <perform>
+                <hint title="`org.apache.camel.CamelContext` property methods have been removed." effort="1"
+                      category-id="mandatory">
+                    <message>The `getProperties` and `setProperty` methods have been removed from `org.apache.camel.CamelContext`. Please use `getGlobalOptions` and `setGlobalOptions` instead</message>
+                    <link title="Camel 3 - Migration Guide: CONFIGURING GLOBAL OPTIONS ON CAMELCONTEXT"
+                          href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_configuring_global_options_on_camelcontext"/>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethods.java
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethods.java
@@ -1,0 +1,28 @@
+package camel2.org.apache.camel.component.jackson.converter;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.camel.CamelContext;
+import org.apache.camel.Exchange;
+import org.apache.camel.ExchangePattern;
+import org.apache.camel.component.jackson.JacksonConstants;
+import org.apache.camel.test.junit4.CamelTestSupport;
+import org.junit.Test;
+
+public class JacksonConversionsSimpleTest extends CamelTestSupport {
+
+    @Override
+    public boolean isUseRouteBuilder() {
+        return false;
+    }
+
+    @Override
+    protected CamelContext createCamelContext() throws Exception {
+        CamelContext context = super.createCamelContext();
+        // enable jackson type converter by setting this property on CamelContext
+        context.getProperties().put(JacksonConstants.ENABLE_TYPE_CONVERTER, "true");
+        return context;
+    }
+
+}

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethodsBlueprint.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethodsBlueprint.xml
@@ -1,0 +1,11 @@
+<blueprint xmlns="http://www.osgi.org/xmlns/blueprint/v1.0.0">
+
+
+<camelContext id="camel1" xmlns="http://camel.apache.org/schema/blueprint">
+    <properties>
+       <property key="org.apache.camel.test" value="this is a test first"/>
+    </properties>
+    <template id="producer1"/>
+  </camelContext>
+  
+</blueprint>

--- a/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethodsSpring.xml
+++ b/rules-reviewed/camel3/camel2/tests/data/java-generic-information/camelContextDeprecatedMethodsSpring.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:camel="http://camel.apache.org/schema/spring"
+       xsi:schemaLocation="
+       http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+       http://camel.apache.org/schema/spring http://camel.apache.org/schema/spring/camel-spring.xsd
+    ">
+
+  <camelContext id="camel1" xmlns="http://camel.apache.org/schema/spring">
+    <properties>
+       <property key="org.apache.camel.test" value="this is a test first"/>
+    </properties>
+    <template id="producer1"/>
+  </camelContext>
+  
+</beans>

--- a/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
@@ -389,6 +389,18 @@
                     <fail message="[java-generic-information] `org.apache.camel.util.toolbox.XsltAggregationStrategy` moved hint was not found!" />
                 </perform>
             </rule>
+            <rule id="java-generic-information-00032-test">
+                <when>
+                    <not>
+                        <iterable-filter size="3">
+                            <hint-exists message="The `getProperties` and `setProperty` methods have been removed*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-generic-information] `org.apache.camel.CamelContext` `getProperties` removed hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
…d from CamelContext

https://issues.redhat.com/browse/WINDUPRULE-460

To run tests: `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-generic-information clean surefire-report:report`

Thanks !