### PR TITLE
WINDUPRULE-425 Fix camel-aws rules to only take into account Camel 2.…

### DIFF
--- a/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-removed-components.windup.xml
@@ -115,7 +115,7 @@
                 </iteration>
             </perform>
             <where param="aws-component">
-                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+                <matches pattern="(aws-cw|aws-ddb|aws-ec2|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-xray)"/>
             </where>
         </rule>
         <rule id="xml-removed-components-00007">
@@ -137,7 +137,7 @@
                 </iteration>
             </perform>
             <where param="aws-component">
-                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+                <matches pattern="(aws-cw|aws-ddb|aws-ec2|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-xray)"/>
             </where>
         </rule>
         <rule id="xml-removed-components-00008">
@@ -159,7 +159,7 @@
                 </iteration>
             </perform>
             <where param="aws-component">
-                <matches pattern="(aws2-cw|aws2-ddb|aws2-ec2|aws2-ecs|aws2-eks|aws2-iam|aws2-kinesis|aws2-kms|aws2-lambda|aws2-mq|aws2-msk|aws2-s3|aws2-ses|aws2-sns|aws2-sqs|aws2-translate|aws-cw|aws-ddb|aws-ec2|aws-ecs|aws-eks|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-msk|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-translate|aws-xray)"/>
+                <matches pattern="(aws-cw|aws-ddb|aws-ec2|aws-iam|aws-kinesis|aws-kms|aws-lambda|aws-mq|aws-s3|aws-sdb|aws-ses|aws-sns|aws-sqs|aws-swf|aws-xray)"/>
             </where>
         </rule>
     </rules>


### PR DESCRIPTION
…x AWS components

https://issues.redhat.com/browse/WINDUPRULE-425

To run tests: `mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=xml-removed-components clean surefire-report:report`

Thanks !