### PR TITLE
WINDUPRULE-587 Spring JAR classification fix

### DIFF
--- a/rules-reviewed/technology-usage/embedded-framework.windup.xml
+++ b/rules-reviewed/technology-usage/embedded-framework.windup.xml
@@ -261,27 +261,6 @@
                 <technology-tag level="INFORMATIONAL">HTTP Client (embedded)</technology-tag>
             </perform>
         </rule>
-        <rule id="embedded-framework-05200">
-            <when>
-                <file filename="spring{*}.jar"/>
-            </when>
-            <perform>
-                <iteration>
-                    <when>
-                        <not>
-                            <has-classification title="Spring {pattern} (embedded)"/>
-                        </not>
-                    </when>
-                    <classification title="Embedded framework - Spring" category-id="information" effort="0">
-                        <description>The application embeds the Spring framework.</description>
-                    </classification>
-                    <technology-tag level="INFORMATIONAL">Spring (embedded)</technology-tag>
-                </iteration>
-            </perform>
-            <where param="pattern">
-                <matches pattern="(Integration|Data|Security|MVC|Batch|Boot|Test)"/>
-            </where>
-        </rule>
         <rule id="embedded-framework-05300">
             <when>
                 <or>
@@ -615,6 +594,28 @@
                 </classification>
                 <technology-tag level="INFORMATIONAL">Spring DI (embedded)</technology-tag>
             </perform>
+        </rule>
+        <!-- this rule has to be always the last one in order to effectively checks for classifications added from previous rules in this ruleset-->
+        <rule id="embedded-framework-05200">
+            <when>
+                <file filename="spring{*}.jar"/>
+            </when>
+            <perform>
+                <iteration>
+                    <when>
+                        <not>
+                            <has-classification title="Embedded framework - Spring {pattern}"/>
+                        </not>
+                    </when>
+                    <classification title="Embedded framework - Spring" category-id="information" effort="0">
+                        <description>The application embeds the Spring framework.</description>
+                    </classification>
+                    <technology-tag level="INFORMATIONAL">Spring (embedded)</technology-tag>
+                </iteration>
+            </perform>
+            <where param="pattern">
+                <matches pattern="(Integration|Data|Security|MVC|Batch|Boot|Test|DI)"/>
+            </where>
         </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/technology-usage/tests/embedded-framework.windup.test.xml
+++ b/rules-reviewed/technology-usage/tests/embedded-framework.windup.test.xml
@@ -249,7 +249,7 @@
                </not>
             </when>
             <perform>
-               <fail message="Expected data not found for rule embedded-framework-02100"/>
+               <fail message="Expected data not found for rule embedded-framework-05200"/>
             </perform>
          </rule>
          <rule id="embedded-framework-05300-test">


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-587

* changed rule position to work effectively
* fixed the `has-classification` pattern
* added `DI` to the pattern (`Spring DI` added in https://github.com/windup/windup-rulesets/pull/431)
* fixed the message in the test to have the right rule ID

This can be tested with `mvn -DrunTestsMatching=embedded-framework clean test`

Screenshot with fixed report (compared to the [wrong ones in Jira](https://issues.redhat.com/browse/WINDUPRULE-587?focusedCommentId=14064009&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-14064009))
![Screenshot from 2020-04-28 16-47-21](https://user-images.githubusercontent.com/7288588/80510876-9d399200-897b-11ea-82bc-e8a4d60df661.png)
![Screenshot from 2020-04-28 16-47-46](https://user-images.githubusercontent.com/7288588/80510883-9f9bec00-897b-11ea-90d1-c29ac848e44b.png)
