### PR TITLE
WINDUPRULE-488 mark camel-core dependencies as migration potential

### DIFF
--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -32,7 +32,7 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-attachments` component has been moved" effort="1" category-id="mandatory">
+                    <hint title="`camel-attachments` component has been moved" effort="1" category-id="potential">
                         <message>`camel-attachments` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
                             org.apache.camel:camel-rest that has to be
                             added as a dependency to your project pom.xml file
@@ -61,7 +61,7 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
+                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="potential">
                         <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
                             org.apache.camel:camel-dataformat that has to be
                             added as a dependency to your project pom.xml file
@@ -90,7 +90,7 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
+                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="potential">
                         <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
                             `org.apache.camel:camel-dataformat` that has to be added as a dependency to your project pom.xml file
                         </message>
@@ -176,7 +176,7 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">
+                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="potential">
                         <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact
                             `org.apache.camel:camel-xpath` that has to be added as a dependency to your project pom.xml file
                         </message>
@@ -198,7 +198,7 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-support` dependency not found" effort="1" category-id="mandatory">
+                    <hint title="`camel-support` dependency not found" effort="1" category-id="potential">
                         <message>`All the classes from `org.apache.camel.util.component` have been moved to `org.apache.camel.support.component.
                             org.apache.camel:camel-support that has to be added as a dependency to your project pom.xml file
                         </message>
@@ -222,7 +222,7 @@
             </when>
             <perform>
                 <iteration over="javaClass">
-                    <hint title="`camel-base` dependency required for `{moved}` class" effort="1" category-id="mandatory">
+                    <hint title="`camel-base` dependency required for `{moved}` class" effort="1" category-id="potential">
                         <message>The class `org.apache.camel.impl.{moved}` has been moved to `org.apache.camel.impl.engine` package in `camel-base`
                             dependency.
                             `org.apache.camel:camel-base` has to be added as a dependency to your project pom.xml file


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-488

to run test: `mvn -DrunTestsMatching=xml-moved-components clean test`

Don't think it's worth reopening the issue for this cc @mrizzi 

Thanks !
