### PR TITLE
WINDUPRULE-603

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/application0/MyRouteBuilder.java
+++ b/rules-reviewed/camel3/camel2/tests/data/xml-moved-components/application0/MyRouteBuilder.java
@@ -10,12 +10,14 @@ import org.apache.camel.impl.WebSpherePackageScanClassResolver;
  * A Camel Java DSL Router
  */
 public class MyRouteBuilder extends RouteBuilder {
-    rest("/say")
+
+
+    public void configure() {
+        rest("/say")
                 .get("/hello").to("direct:hello")
                 .get("/bye").consumes("application/json")
                 .post("/bye");
 
-    public void configure() {
         from("direct:xslt-copy-all")
             .to("xslt:xslt/copy-all.xsl")
             .to("file:target/messages/others")

--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -11,8 +11,8 @@
             <rule id="xml-moved-components-groovy-00000-test">
                 <when>
                     <not>
-                        <iterable-filter size="15">
-                            <hint-exists message="`camel-.*` component has been moved from `camel-core`*"/>
+                        <iterable-filter size="1">
+                            <hint-exists message="`*camel-rest`, `camel-dataformat`, `camel-direct-vm`, `camel-log`, `camel-direct`, `camel-validator`, `camel-language`, `camel-zip-deflater`, `camel-scheduler`, `camel-timer`, `camel-ref`, `camel-file`, `camel-vm`, `camel-stub`, `camel-xslt`, `camel-dataset`, `camel-bean`, `camel-browse.*`" />
                         </iterable-filter>
                     </not>
                 </when>
@@ -20,90 +20,7 @@
                     <fail message="[xml-moved-components] Camel dependency moved hint was not found!"/>
                 </perform>
             </rule>
-            <rule id="xml-moved-components-groovy-00000-test-1">
-                <when>
-                    <not>
-                        <iterable-filter size="1">
-                            <hint-exists message="`camel-rest` required for using rest DSL.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-rest dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00006-test">
-                <when>
-                    <not>
-                        <iterable-filter size="1">
-                            <hint-exists message="`camel-attachments` required for using rest DSL.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-attachments dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00007-test">
-                <when>
-                    <not>
-                        <iterable-filter size="2">
-                            <hint-exists message="`camel-dataformat` dependency required.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-dataformat dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00008-test">
-                <when>
-                    <not>
-                        <iterable-filter size="2">
-                            <hint-exists message="`camel-dataformat` dependency required.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-dataformat dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00009-test">
-                <when>
-                    <not>
-                        <iterable-filter size="2">
-                            <hint-exists message="`camel-zip-deflater` dependency required.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00010-test">
-                <when>
-                    <not>
-                        <iterable-filter size="2">
-                            <hint-exists message="`camel-zip-deflater` dependency required.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] camel-zip-deflater dependency moved hint was not found!"/>
-                </perform>
-            </rule>
-            <rule id="xml-moved-components-00011-test">
-                <when>
-                    <not>
-                        <iterable-filter size="1">
-                            <hint-exists message="`camel-xpath` dependency required.*"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[xml-moved-components] `camel-xpath` dependency moved hint was not found!"/>
-                </perform>
-            </rule>
+
             <rule id="xml-moved-components-00012-test">
                 <when>
                     <not>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.groovy
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.groovy
@@ -13,6 +13,7 @@ import org.jboss.windup.reporting.category.IssueCategoryRegistry
 import org.jboss.windup.reporting.config.Hint
 import org.jboss.windup.reporting.config.Link
 import org.jboss.windup.rules.apps.java.condition.JavaClass
+import org.jboss.windup.rules.apps.java.model.JavaClassModel
 import org.jboss.windup.rules.apps.xml.condition.XmlFile
 import org.jboss.windup.rules.apps.xml.model.XmlFileModel
 import org.jboss.windup.rules.apps.xml.model.XmlTypeReferenceModel
@@ -26,13 +27,66 @@ import java.util.function.Function
 
 final String FROM_XML_FILES_IN_PROJECT = "xmlFilesInProject"
 final String FROM_FILES_IN_PROJECT = "filesInProject"
-final Set<String> componentsMoved = ["language", "bean", "direct", "xslt", "browse", "dataset", "direct-vm", "file", "log", "mock", "ref", "saga", "scheduler", "seda", "stub", "timer", "validator", "vm"]
+
+/*
+returns xpath condition that counts elements
+ */
+ String countXpath(String... elements) {
+    StringBuilder sb = new StringBuilder("//*[( ")
+    for (i = 0; i < elements.length; i++) {
+        sb.append("count(c:" + elements[i] + ")")
+        if (i < (elements.length - 1)) {
+            sb.append(" + ")
+        }
+    }
+    sb.append(")> 0]")
+    return sb.toString()
+}
+
+static String componentNameExpression(String componentName) {
+    return "(\"$componentName:"
+}
+
+static String componentNameXpath(String component) {
+    return "//*/c:route/*[starts-with(@uri, '$component:')]"
+}
+
+final Map<String, String[]> movedComponents = [
+        // component name: [xml xpath, java matches expression ]
+        "language"     : [componentNameXpath("language"), componentNameExpression("language")],
+        "bean"         : [componentNameXpath("bean"), componentNameExpression("bean")],
+        "direct"       : [componentNameXpath("direct"), componentNameExpression("direct")],
+        "xslt"         : [componentNameXpath("xslt"), componentNameExpression("xslt")],
+        "browse"       : [componentNameXpath("browse"), componentNameExpression("browse")],
+        "dataset"      : [componentNameXpath("dataset"), componentNameExpression("dataset")],
+        "direct-vm"    : [componentNameXpath("direct-vm"), componentNameExpression("direct-vm")],
+        "file"         : [componentNameXpath("file"), componentNameExpression("file")],
+        "log"          : [componentNameXpath("log"), componentNameExpression("log")],
+        "mock"         : [componentNameXpath("mock"), componentNameExpression("mock")],
+        "ref"          : [componentNameXpath("ref"), componentNameExpression("ref")],
+        "saga"         : [componentNameXpath("saga"), componentNameExpression("saga")],
+        "scheduler"    : [componentNameXpath("scheduler"), componentNameExpression("scheduler")],
+        "seda"         : [componentNameXpath("seda"), componentNameExpression("seda")],
+        "stub"         : [componentNameXpath("stub"), componentNameExpression("stub")],
+        "timer"        : [componentNameXpath("timer"), componentNameExpression("timer")],
+        "validator"    : [componentNameXpath("validator"), componentNameExpression("validator")],
+        "vm"           : [componentNameXpath("vm"), componentNameExpression("vm")],
+        "rest"         : [countXpath("rest", "get", "post", "put", "delete"), "rest({*})"],
+        "xslt "         : [countXpath("xpath"), ".xpath({*})"],
+        "zip-deflater" : [countXpath("zip"), ".zip({*})"],
+        "zip-deflater ": [countXpath("gzip"), ".gzip({*})"],
+        "dataformat "  : [countXpath("marshal,unmarshal,dataformats"), ".marshal({*})"],
+        "dataformat"   : ["", ".unmarshal({*})"],
+        "attachements ": ["", ".addAttachement({*})"]
+]
 
 final IssueCategory optionalIssueCategory = new IssueCategoryRegistry().getByID(IssueCategoryRegistry.OPTIONAL)
 final Link modularizationLink = Link.to("Camel 3 - Migration Guide: Modularization of camel-core", "https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core")
 
-final BiFunction<String, String, Boolean> isThereArtifactId = { String xmlDependenciesBlock, String component -> 
-    xmlDependenciesBlock.contains("<artifactId>camel-$component</artifactId>" as CharSequence) }
+
+final BiFunction<String, String, Boolean> isThereArtifactId = { String xmlDependenciesBlock, String component ->
+    xmlDependenciesBlock.contains("<artifactId>camel-$component</artifactId>" as CharSequence)
+}
 
 final BiFunction<String, String, Condition> xmlCondition = { String component, String namespace ->
     XmlFile.from(FROM_XML_FILES_IN_PROJECT)
@@ -41,66 +95,58 @@ final BiFunction<String, String, Condition> xmlCondition = { String component, S
             .as("$component-$namespace")
 }
 
-final Function<String, Condition> javaCondition = { String component ->
+final BiFunction<String, String, Condition> xmlConditionWithXpath = { String xpath, String namespace ->
+    XmlFile.from(FROM_XML_FILES_IN_PROJECT)
+            .matchesXpath(xpath)
+            .namespace("c", namespace)
+}
+
+final Function<String, Condition> javaConditionMatches = { String matches ->
     FileContent.from(FROM_FILES_IN_PROJECT)
-            .matches("(\"$component:")
+            .matches(matches)
             .inFileNamed("{*}.java")
-            .as("$component-java")
 }
 
 ruleSet("xml-moved-components-groovy")
-    .addSourceTechnology(new TechnologyReference("camel", "[2,3)"))
-    .addTargetTechnology(new TechnologyReference("camel", "[3,)"))
-    .addRule()
-    .when(
-        XmlFile.matchesXpath("/m:project/m:dependencies[m:dependency/m:groupId/text() = 'org.apache.camel']")
-            .inFile("pom.xml").namespace("m", "http://maven.apache.org/POM/4.0.0")
-    )
-    .perform(new AbstractIterationOperation<XmlTypeReferenceModel>()
-    {
-        void perform(GraphRewrite event, EvaluationContext context, XmlTypeReferenceModel payload) {
-            final FileModel fileModel = payload.getFile()
-            final String filePath = StringUtils.removeEnd(fileModel.getFilePath(), fileModel.getFileName())
-            Query.fromType(XmlFileModel.class).withProperty(FileModel.FILE_PATH, QueryPropertyComparisonType.CONTAINS_TOKEN, filePath).as(FROM_XML_FILES_IN_PROJECT).evaluate(event, context)
-            Query.fromType(FileModel.class).withProperty(FileModel.FILE_PATH, QueryPropertyComparisonType.CONTAINS_TOKEN, filePath).as(FROM_FILES_IN_PROJECT).evaluate(event, context)
-            final String xmlDependenciesBlock = payload.getSourceSnippit()
-            // rules xml-moved-components-0000{0-2}
-            componentsMoved.stream()
-                .filter { component -> !isThereArtifactId.apply(xmlDependenciesBlock, component) }
-                .filter { component ->
-                    xmlCondition.apply(component, "http://camel.apache.org/schema/spring").evaluate(event, context) ||
-                    xmlCondition.apply(component, "http://camel.apache.org/schema/blueprint").evaluate(event, context) ||
-                    javaCondition.apply(component).evaluate(event, context)}
-                .each { component ->
-                    ((Hint) Hint.titled("`camel-$component` has been moved")
-                        .withText("""`camel-$component` component has been moved from `camel-core` 
-                            to separate artifact `org.apache.camel:camel-$component` that has to be added as a 
-                            dependency to your project `pom.xml` file""")
+        .addSourceTechnology(new TechnologyReference("camel", "[2,3)"))
+        .addTargetTechnology(new TechnologyReference("camel", "[3,)"))
+        .addRule()
+        .when(
+                XmlFile.matchesXpath("/m:project/m:dependencies[m:dependency/m:groupId/text() = 'org.apache.camel']")
+                        .inFile("pom.xml").namespace("m", "http://maven.apache.org/POM/4.0.0")
+        )
+        .perform(new AbstractIterationOperation<XmlTypeReferenceModel>() {
+            void perform(GraphRewrite event, EvaluationContext context, XmlTypeReferenceModel payload) {
+                Set<String> usedComponents = []
+                final FileModel fileModel = payload.getFile()
+                final String filePath = StringUtils.removeEnd(fileModel.getFilePath(), fileModel.getFileName())
+                Query.fromType(XmlFileModel.class).withProperty(FileModel.FILE_PATH, QueryPropertyComparisonType.CONTAINS_TOKEN, filePath).as(FROM_XML_FILES_IN_PROJECT).evaluate(event, context)
+                Query.fromType(FileModel.class).withProperty(FileModel.FILE_PATH, QueryPropertyComparisonType.CONTAINS_TOKEN, filePath).as(FROM_FILES_IN_PROJECT).evaluate(event, context)
+                final String xmlDependenciesBlock = payload.getSourceSnippit()
+                // rules xml-moved-components-0000{0-2}
+                movedComponents.keySet().stream()
+                        .filter { component -> !isThereArtifactId.apply(xmlDependenciesBlock, component.replaceAll("\\s","")) }
+                        .filter { component ->
+                            (movedComponents[component][0] != "" ? xmlCondition.apply(movedComponents[component][0], "http://camel.apache.org/schema/spring").evaluate(event, context) : false) ||
+                                    (movedComponents[component][0] != "" ? xmlConditionWithXpath.apply(movedComponents[component][0],
+                                            "http://camel.apache.org/schema/blueprint").evaluate(event, context) : false) ||
+                                    (movedComponents[component][1] != "" ? javaConditionMatches.apply(movedComponents[component][1]).evaluate(event, context) : false)
+                        }
+                        .each { component -> usedComponents.add(component.replaceAll("\\s","")) }
+
+                String components = usedComponents.stream()
+                        .map { component -> "`camel-$component`" }.toArray().toString()
+
+                ((Hint) Hint.titled("Modularization of camel-core")
+                        .withText(" $components components were moved out of `camel-core` to separate artifacts. Maven users of Apache Camel can keep using the dependency `camel-core`" +
+                                "which has transitive dependencies on all of its modules, except for `camel-main`" +
+                                "and therefore no migration is needed. However, users who want to trim the size of the classes on the classpath," +
+                                "can use fine grained Maven dependencies on only the modules needed.")
                         .withIssueCategory(optionalIssueCategory)
                         .with(modularizationLink)
                         .withEffort(1))
                         .perform(event, context, payload)
-                }
-            // rules xml-moved-components-0000{3-5}
-            Condition javaClass = And.all(
-                    JavaClass.from(FROM_FILES_IN_PROJECT).references("org.apache.camel.builder.RouteBuilder").at(TypeReferenceLocation.INHERITANCE).as("routeBuilders"),
-                    FileContent.from("routeBuilders").matches("rest({*})").as("rest-java")
-            )
-            final String restXmlTagCounts = "//*[(count(c:rest)+count(c:get)+count(c:post)+count(c:put)+count(c:delete))>0 ]"
-            Condition springContent = XmlFile.from(FROM_XML_FILES_IN_PROJECT).matchesXpath(restXmlTagCounts).namespace("c", "http://camel.apache.org/schema/spring").as("rest-spring")
-            Condition blueprintContent = XmlFile.from(FROM_XML_FILES_IN_PROJECT).matchesXpath(restXmlTagCounts).namespace("c", "http://camel.apache.org/schema/blueprint").as("rest-blueprint")
-            if (javaClass.evaluate(event, context) ||
-                springContent.evaluate(event, context) ||
-                blueprintContent.evaluate(event, context))
-            {
-                ((Hint) Hint.titled("`camel-rest` component has been moved")
-                .withText("""`camel-rest` required for using rest DSL.  
-                    Component has been moved from `camel-core` to separate artifact `org.apache.camel:camel-rest` that has to be added as a dependency to your project `pom.xml` file""")
-                .withIssueCategory(optionalIssueCategory)
-                .with(modularizationLink)
-                .withEffort(1))
-                .perform(event, context, payload)
+
             }
-        }
-    })
-    .withId("xml-moved-components-groovy-00000")
+        })
+        .withId("xml-moved-components-groovy-00000")

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -20,172 +20,15 @@
         <rule id="xml-moved-components-00003">
         <rule id="xml-moved-components-00004">
         <rule id="xml-moved-components-00005">
--->
+
         <rule id="xml-moved-components-00006">
-            <when>
-                <!--               <filecontent pattern="'xslt:'" filename="{*}.java"/>-->
-                <filecontent pattern=".addAttachment{*}" filename="{*}.java"/>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-attachments'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-attachments` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-attachments` required for using rest DSL. Component has been moved from `camel-core` to separate artifact
-                            org.apache.camel:camel-rest that has to be
-                            added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
-
         <rule id="xml-moved-components-00007">
-            <when>
-
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
-                    <location>INHERITANCE</location>
-                </javaclass>
-                <or>
-                    <filecontent pattern=".marshal({*})" from="routeBuilders"/>
-                    <filecontent pattern="unmarshal({*})" from="routeBuilders"/>
-                </or>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
-                            org.apache.camel:camel-dataformat that has to be
-                            added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
         <rule id="xml-moved-components-00008">
-            <when>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-
-                <or>
-                    <xmlfile matches="//*[(count(b:marshal)+count(b:unmarshal)+count(b:dataformats)) >0]">
-                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
-                    </xmlfile>
-                    <xmlfile matches="//*[(count(c:marshal)+count(c:unmarshal)+ count(c:dataformats)) > 0]">
-                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
-                    </xmlfile>
-                </or>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-dataformat` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-dataformat` dependency required. Component has been moved from `camel-core` to separate artifact
-                            `org.apache.camel:camel-dataformat` that has to be added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
         <rule id="xml-moved-components-00009">
-            <when>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-zip-deflater'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
-                    <location>INHERITANCE</location>
-                </javaclass>
-                <or>
-                    <filecontent pattern=".zip({*})" from="routeBuilders"/>
-                    <filecontent pattern=".gzip({*})" from="routeBuilders"/>
-                </or>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
-                            `org.apache.camel:camel-zip-deflater` that has to be added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
         <rule id="xml-moved-components-00010">
-            <when>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-dataformat'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-
-                <or>
-                    <xmlfile matches="//*[(count(b:zip)+count(b:gzip)) >0]">
-                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
-                    </xmlfile>
-                    <xmlfile matches="//*[(count(c:gzip)+count(c:zip)) > 0]">
-                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
-                    </xmlfile>
-                </or>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-zip-deflater` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-zip-deflater` dependency required. Component has been moved from `camel-core` to separate artifact
-                            `org.apache.camel:camel-zip-deflater` that has to be
-                            added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_zip_and_gzip_dataformat"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
         <rule id="xml-moved-components-00011">
-            <when>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-xpath'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-                <javaclass references="org.apache.camel.builder.RouteBuilder" as="routeBuilders">
-                    <location>INHERITANCE</location>
-                </javaclass>
-                <or>
-                    <filecontent pattern=".xpath({*})" from="routeBuilders"/>
-                    <xmlfile matches="//*[count(b:xpath) >0]">
-                        <namespace prefix="b" uri="http://camel.apache.org/schema/blueprint"/>
-                    </xmlfile>
-                    <xmlfile matches="//*[count(c:xpath) > 0]">
-                        <namespace prefix="c" uri="http://camel.apache.org/schema/spring"/>
-                    </xmlfile>
-                </or>
-            </when>
-            <perform>
-                <iteration over="dependencies-block">
-                    <hint title="`camel-xpath` component has been moved" effort="1" category-id="mandatory">
-                        <message>`camel-xpath` dependency required. Component has been moved from `camel-core` to separate artifact
-                            `org.apache.camel:camel-xpath` that has to be added as a dependency to your project pom.xml file
-                        </message>
-                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
-                                title="Camel 3 - Migration Guide"/>
-                    </hint>
-                </iteration>
-            </perform>
-        </rule>
+
+        -->
         <rule id="xml-moved-components-00012">
             <when>
                 <xmlfile as="dependencies-block" in="pom.xml"
@@ -198,12 +41,14 @@
             </when>
             <perform>
                 <iteration over="dependencies-block">
-                    <hint title="`camel-support` dependency not found" effort="1" category-id="mandatory">
-                        <message>`All the classes from `org.apache.camel.util.component` have been moved to `org.apache.camel.support.component.
-                            org.apache.camel:camel-support that has to be added as a dependency to your project pom.xml file
+                    <hint title="The classes from `org.apache.camel.util.component` have been moved" effort="1" category-id="mandatory">
+                        <message>All the classes from `org.apache.camel.util.component` have been moved to `org.apache.camel.support.component`.
+                            `org.apache.camel:camel-support` is a transitive dependency of `camel-core` but it could be used also separately to trim the application size.
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
                                 title="Camel 3 - Migration Guide"/>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                              title="Camel 3 - Migration Guide: Modularization of camel-core"/>
                     </hint>
                 </iteration>
             </perform>
@@ -222,13 +67,15 @@
             </when>
             <perform>
                 <iteration over="javaClass">
-                    <hint title="`camel-base` dependency required for `{moved}` class" effort="1" category-id="mandatory">
+                    <hint title="`org.apache.camel.impl.{moved}` class has been moved" effort="1" category-id="mandatory">
                         <message>The class `org.apache.camel.impl.{moved}` has been moved to `org.apache.camel.impl.engine` package in `camel-base`
                             dependency.
-                            `org.apache.camel:camel-base` has to be added as a dependency to your project pom.xml file
+                            `org.apache.camel:camel-base` is a transitive dependency of `camel-core` but it could be used also separately to trim the application size.
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_generic_information"
                                 title="Camel 3 - Migration Guide: General information"/>
+                        <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_modularization_of_camel_core"
+                              title="Camel 3 - Migration Guide: Modularization of camel-core"/>
                     </hint>
                 </iteration>
             </perform>


### PR DESCRIPTION
Refactor rules for component moved out of camel-core. Because of new dependencies not being mandatory, current rule throws only one hint with list of components that were used in to project with message that components could be moved. 

Tests can be run with ` mvn -DrunTestsMatching=xml-moved-components clean test`
