### PR TITLE
Winduprule 610

### DIFF
--- a/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
+++ b/rules-reviewed/camel3/camel2/java-generic-information.windup.xml
@@ -74,26 +74,6 @@
                 </iteration>
             </perform>
         </rule>
-        <rule id="java-generic-information-00003">
-            <when>
-                <javaclass references="org.apache.camel.util.component.{*}">
-                    <location>IMPORT</location>
-                </javaclass>
-            </when>
-            <perform>
-                <hint title="`org.apache.camel.util.component` content has been moved" effort="1" category-id="mandatory">
-                    <message>
-                        All the classes from `org.apache.camel.util.component` have been moved to `org.apache.camel.support.component`.
-                    </message>
-                    <link title="Camel 3 - Migration Guide: Generic Information"
-                            href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_generic_information"/>
-                    <quickfix type="REPLACE" name="Support-replace2">
-                        <replacement>org.apache.camel.support.component</replacement>
-                        <search>org.apache.camel.util.component</search>
-                    </quickfix>
-                </hint>
-            </perform>
-        </rule>
         <rule id="java-generic-information-00004">
             <when>
                 <javaclass references="org.apache.camel.impl.{registry}" as="javaClass">

--- a/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/java-generic-information.windup.test.xml
@@ -46,18 +46,6 @@
                     <fail message="[generic-information] Camel dependency moved hint was not found!"/>
                 </perform>
             </rule>
-            <rule id="java-generic-information-00003-test">
-                <when>
-                    <not>
-                        <iterable-filter size="1">
-                            <hint-exists message="All the classes from `org.apache.camel.util.component`*`"/>
-                        </iterable-filter>
-                    </not>
-                </when>
-                <perform>
-                    <fail message="[generic-information] Camel dependency moved hint was not found!"/>
-                </perform>
-            </rule>
             <rule id="java-generic-information-00004-test">
                 <when>
                     <not>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.xml
@@ -31,16 +31,12 @@
         -->
         <rule id="xml-moved-components-00012">
             <when>
-                <xmlfile as="dependencies-block" in="pom.xml"
-                        matches="/m:project/m:dependencies[count(m:dependency/m:artifactId[text()='camel-support'])=0]">
-                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                </xmlfile>
-                <javaclass references="org.apache.camel.util.component.{*}">
+                <javaclass references="org.apache.camel.util.component.{*}" as="javaClass">
                     <location>IMPORT</location>
                 </javaclass>
             </when>
             <perform>
-                <iteration over="dependencies-block">
+                <iteration over="javaClass">
                     <hint title="The classes from `org.apache.camel.util.component` have been moved" effort="1" category-id="mandatory">
                         <message>All the classes from `org.apache.camel.util.component` have been moved to `org.apache.camel.support.component`.
                             `org.apache.camel:camel-support` is a transitive dependency of `camel-core` but it could be used also separately to trim the application size.
@@ -58,18 +54,11 @@
                 <javaclass references="org.apache.camel.impl.{moved}" as="javaClass">
                     <location>IMPORT</location>
                 </javaclass>
-                <not>
-                    <xmlfile as="dependencies" in="pom.xml"
-                            matches="/m:project/m:dependencies/m:dependency/m:artifactId[text()='camel-base']">
-                        <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
-                    </xmlfile>
-                </not>
             </when>
             <perform>
                 <iteration over="javaClass">
                     <hint title="`org.apache.camel.impl.{moved}` class has been moved" effort="1" category-id="mandatory">
-                        <message>The class `org.apache.camel.impl.{moved}` has been moved to `org.apache.camel.impl.engine` package in `camel-base`
-                            dependency.
+                        <message>The class `org.apache.camel.impl.{moved}` has been moved to `org.apache.camel.impl.engine` package in `camel-base` dependency.
                             `org.apache.camel:camel-base` is a transitive dependency of `camel-core` but it could be used also separately to trim the application size.
                         </message>
                         <link href="https://camel.apache.org/manual/latest/camel-3-migration-guide.html#_generic_information"


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-610

To run tests:  `mvn -DrunTestsMatching=xml-moved-components clean test -nsu` && `mvn -DrunTestsMatching=java-generic-information clean test -nsu`

I've simply removed the check for `camel-support` and `camel-base` as it's not needed.

I've also noticed, while testing, that java-generic-information-00003 is a duplicate of xml-moved-components-00012 so I removed it. cc @jonathanvila @mmelko 

Thanks!