### PR TITLE
Removed broken links to EAP 4.x documentation

### DIFF
--- a/rules-reviewed/eap6/jboss-eap4/eap4-xml-config.windup.xml
+++ b/rules-reviewed/eap6/jboss-eap4/eap4-xml-config.windup.xml
@@ -421,7 +421,7 @@
                 <hint title="JBoss EAP 4 EJB container configuration" effort="3" category-id="mandatory">
                     <message>
                         <![CDATA[
-                        JBoss EAP 4 and 5 allows overriding the container settings in `jboss.xml` files.
+                        JBoss EAP 4 and 5 allow overriding the container settings in `jboss.xml` files.
                         Extending `"Standard Stateless SessionBean"` allows configuring the instance pool.
                         Bean-specific instance pool can be set with one line in JBoss EAP 6 management CLI.
                         ]]>
@@ -429,7 +429,7 @@
                     <link title="JBoss EAP 6 Migration Guide: Replace the jboss.xml File" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/index#sect-EJB_Changes"/>
                     <link title="Assign Bean Pools for Session and Message-Driven Beans" href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#Assign_Bean_Pools_for_Session_and_Message-Driven_Beans"/>
                     <link title="jboss.xml DTD" href="http://www.jboss.org/j2ee/dtd/jboss_5_0.dtd"/>
-                    <link title="JBoss EAP 4: Container configuration information" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#EJBDeployer_MBean-Container_configuration_information"/>
+                    <link title="The EJB Container" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#EJBs_on_JBoss-The_EJB_Container"/>
                     <tag>http</tag>
                     <tag>web</tag>
                 </hint>
@@ -451,7 +451,7 @@
                     <link title="JBoss EAP 6 Migration Guide: Replace the jboss.xml File" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/index#sect-EJB_Changes"/>
                     <link title="Assign Bean Pools for Session and Message-Driven Beans" href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#Assign_Bean_Pools_for_Session_and_Message-Driven_Beans"/>
                     <link title="jboss.xml DTD" href="http://www.jboss.org/j2ee/dtd/jboss_5_0.dtd"/>
-                    <link title="JBoss EAP 4: Container configuration information" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#EJBDeployer_MBean-Container_configuration_information"/>
+                    <link title="The EJB Container" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#EJBs_on_JBoss-The_EJB_Container"/>
                     <tag>ejb</tag>
                     <tag>pool</tag>
                 </hint>
@@ -465,7 +465,7 @@
                 <hint title="JBoss EAP 4 EJB container configuration" effort="3" category-id="mandatory">
                     <message>
                         <![CDATA[
-                        JBoss EAP 4 and 5 allows overriding the container settings in `jboss.xml` files.
+                        JBoss EAP 4 and 5 allow overriding the container settings in `jboss.xml` files.
                         Extending `"Standard Message Driven Bean"` allows configuring the instance pool.
                         MDB's bean-specific instance pool can be set with one line in JBoss EAP 6 management CLI.
                         Use the `bean-instance-pool-ref` CLI node of the respective configuration part.
@@ -474,7 +474,7 @@
                     <link title="JBoss EAP 6 Migration Guide: Replace the jboss.xml File" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/index#sect-EJB_Changes"/>
                     <link title="Assign Bean Pools for Session and Message-Driven Beans" href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#Assign_Bean_Pools_for_Session_and_Message-Driven_Beans"/>
                     <link title="jboss.xml DTD" href="http://www.jboss.org/j2ee/dtd/jboss_5_0.dtd"/>
-                    <link title="JBoss EAP 4: Container configuration information" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#EJBDeployer_MBean-Container_configuration_information"/>
+                    <link title="The EJB Container" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#EJBs_on_JBoss-The_EJB_Container"/>
                     <tag>ejb</tag>
                     <tag>pool</tag>
                 </hint>
@@ -488,7 +488,7 @@
                 <hint title="JBoss EAP 4 EJB container configuration" effort="3" category-id="mandatory">
                     <message>
                         <![CDATA[
-                        JBoss EAP 4 and 5 allows overriding the container settings in `jboss.xml` files.
+                        JBoss EAP 4 and 5 allow overriding the container settings in `jboss.xml` files.
                         Extending `"Singleton Message Driven Bean"` allows configuring the instance pool.
                         Singleton Message Driven Bean's bean-specific bean-specific instance pool can be set with one line in JBoss EAP 6 management CLI.
                         Use the `bean-instance-pool-ref` CLI node of the respective configuration part.
@@ -497,7 +497,7 @@
                     <link title="JBoss EAP 6 Migration Guide: Replace the jboss.xml File" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/index#sect-EJB_Changes"/>
                     <link title="Assign Bean Pools for Session and Message-Driven Beans" href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#Assign_Bean_Pools_for_Session_and_Message-Driven_Beans"/>
                     <link title="jboss.xml DTD" href="http://www.jboss.org/j2ee/dtd/jboss_5_0.dtd"/>
-                    <link title="JBoss EAP 4: Container configuration information" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#EJBDeployer_MBean-Container_configuration_information"/>
+                    <link title="The EJB Container" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#EJBs_on_JBoss-The_EJB_Container"/>
                     <tag>ejb</tag>
                     <tag>pool</tag>
                 </hint>
@@ -511,7 +511,7 @@
                 <hint title="JBoss EAP 4 EJB container configuration" effort="3" category-id="mandatory">
                     <message>
                         <![CDATA[
-                        JBoss EAP 4 and 5 allows overriding the container settings in `jboss.xml` files.
+                        JBoss EAP 4 and 5 allow overriding the container settings in `jboss.xml` files.
                         Extending `"Standard Message Inflow Driven Bean"` allows configuring the instance pool.
                         Standard Message Inflow Driven Bean's bean-specific bean-specific instance pool can be set with one line in JBoss EAP 6 management CLI.
                         Use the `bean-instance-pool-ref` CLI node of the respective configuration part.
@@ -520,7 +520,7 @@
                     <link title="JBoss EAP 6 Migration Guide: Replace the jboss.xml File" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/index#sect-EJB_Changes"/>
                     <link title="Assign Bean Pools for Session and Message-Driven Beans" href="https://access.redhat.com/documentation/en-US/JBoss_Enterprise_Application_Platform/6.4/html-single/Administration_and_Configuration_Guide/index.html#Assign_Bean_Pools_for_Session_and_Message-Driven_Beans"/>
                     <link title="jboss.xml DTD" href="http://www.jboss.org/j2ee/dtd/jboss_5_0.dtd"/>
-                    <link title="JBoss EAP 4: Container configuration information" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#EJBDeployer_MBean-Container_configuration_information"/>
+                    <link title="The EJB Container" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#EJBs_on_JBoss-The_EJB_Container"/>
                     <tag>ejb</tag>
                     <tag>pool</tag>
                 </hint>

--- a/rules-reviewed/eap6/jboss-eap5/jboss-eap5-xml.windup.xml
+++ b/rules-reviewed/eap6/jboss-eap5/jboss-eap5-xml.windup.xml
@@ -245,7 +245,7 @@
                     <description>
                         The `jbosscmp-jdbc.xml` is a deployment decriptor controlling the Container Managed Persistence (CMP).
                     </description>
-                    <link title="JBoss EAP 4: The jbosscmp-jdbc Structure" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#The_CMP_Engine-The_jbosscmp_jdbc_Structure"/>
+                    <link title="JBoss EAP 5 - The jbosscmp-jdbc Structure" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#The_CMP_Engine-The_jbosscmp_jdbc_Structure"/>
                     <tag>jdbc</tag>
                     <tag>ejb2</tag>
                     <tag>jboss-eap5</tag>

--- a/rules-reviewed/eap7/eap4and5/jboss-eap4and5to6and7-xml.windup.xml
+++ b/rules-reviewed/eap7/eap4and5/jboss-eap4and5to6and7-xml.windup.xml
@@ -55,8 +55,8 @@
                         ]]>
                     </message>
                     <link title="BarrierController service in JBoss EAP 6 " href="https://access.redhat.com/solutions/410953"/>
-                    <link title="JBoss EAP 4.2 - The BarrierController Service" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.2/html/server_configuration_guide/additional_services-the_barriercontroller_service"/>
                     <link title="JBoss EAP 6 - Migration Guide" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/6.4/html-single/migration_guide/#Review_The_List_of_Deprecated_and_Unsupported_Features"/>
+                    <link title="JBoss EAP 5 - HASingleton Deployment Options" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#idm139776751035360"/>
                 </hint>
             </perform>
         </rule>

--- a/rules-reviewed/eap7/eap5and6/jboss-eap5and6to7-xml.windup.xml
+++ b/rules-reviewed/eap7/eap5and6/jboss-eap5and6to7-xml.windup.xml
@@ -129,8 +129,8 @@
                         Support for EJB Entity Beans is optional in Java EE 7 and they are not supported in JBoss EAP 7.
                         This means CMP entity beans must be rewritten to use Java Persistence API (JPA) entities.
                     </description>
-                    <link title="JBoss EAP 4: The jbosscmp-jdbc Structure" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/4.3/html-single/server_configuration_guide/#The_CMP_Engine-The_jbosscmp_jdbc_Structure"/>
                     <link title="Migrate Entity Beans to JPA" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/html-single/migration_guide/#migrate_entity_beans_to_jpa"/>
+                    <link title="JBoss EAP 5 - The jbosscmp-jdbc Structure" href="https://access.redhat.com/documentation/en-us/jboss_enterprise_application_platform/5/html-single/administration_and_configuration_guide/index#The_CMP_Engine-The_jbosscmp_jdbc_Structure"/>
                     <tag>jdbc</tag>
                     <tag>ejb2</tag>
                     <tag>jboss-eap5</tag>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-644

EAP 4.x documentation is no longer supported. Broken links have been removed from rulesets.