### PR TITLE
WINDUPRULE-651 Nightly build failures due to obsolete links eap7/eap6…

### DIFF
--- a/rules-reviewed/eap7/eap6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap6/resteasy.windup.xml
@@ -237,7 +237,7 @@
                     <message>`org.jboss.resteasy.core.interception.InterceptorRegistry` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="http://www.oracle.com/technetwork/articles/java/jaxrs20-1929352.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>
@@ -251,7 +251,7 @@
                     <message>`org.jboss.resteasy.core.interception.InterceptorRegistryListener` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="http://www.oracle.com/technetwork/articles/java/jaxrs20-1929352.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>
@@ -341,7 +341,7 @@
                     <message>`org.jboss.resteasy.spi.interception.ClientExecutionContext` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="http://www.oracle.com/technetwork/articles/java/jaxrs20-1929352.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>

--- a/rules-reviewed/eap7/eap6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap6/resteasy.windup.xml
@@ -251,7 +251,7 @@
                     <message>`org.jboss.resteasy.core.interception.InterceptorRegistryListener` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>

--- a/rules-reviewed/eap7/eap6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap6/resteasy.windup.xml
@@ -237,7 +237,7 @@
                     <message>`org.jboss.resteasy.core.interception.InterceptorRegistry` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>
@@ -836,4 +836,3 @@
         </rule>
     </rules>
 </ruleset>
-

--- a/rules-reviewed/eap7/eap6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap6/resteasy.windup.xml
@@ -341,7 +341,7 @@
                     <message>`org.jboss.resteasy.spi.interception.ClientExecutionContext` is deprecated in favor of the JAX-RS 2.0 Interceptor and filter API.</message>
                     <link title="RESTEasy SPI Application Changes"
                         href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.0/single/migration_guide/#migrate_resteasy_deprecated_classes" />
-                    <link href="https://www.oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
+                    <link href="https://oracle.com/technical-resources/articles/java/jaxrs20.html" title="Java EE 7 and JAX-RS 2.0" />
                     <tag>resteasy</tag>
                 </hint>
             </perform>


### PR DESCRIPTION
The eap7/eap6/resteasy.windup.xml ruleset conatins 3 rules that reference the same obsolete link. Details in the jira. The links have been replaced. To test the resteasy rules I used the command mvn -DrunTestsMatching=resteasy clean test 