### PR TITLE
WINDUPRULE-656: Spring Boot JMX to Quarkus rule - alter hint to mention hotspot compilation support

### DIFF
--- a/rules-reviewed/quarkus/springboot/springboot-jmx-to-quarkus.windup.xml
+++ b/rules-reviewed/quarkus/springboot/springboot-jmx-to-quarkus.windup.xml
@@ -25,7 +25,8 @@
                     <message>
                         Spring JMX XML configuration detected:
 
-                        Spring JMX is not supported by Quarkus with GraalVM on a Native Image
+                        Spring JMX is not supported by Quarkus with the GraalVM Native compilation.
+                        Spring JMX can be used with the Quarkus Hotspot compilation however.
                     </message>
                 </hint>
             </perform>
@@ -41,7 +42,8 @@
                     <message>
                         Spring JMX annotation configuration detected:
 
-                        Spring JMX is not supported by Quarkus with GraalVM on a Native Image
+                        Spring JMX is not supported by Quarkus with the GraalVM Native compilation.
+                        Spring JMX can be used with the Quarkus Hotspot compilation however.
                     </message>
                 </hint>
             </perform>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-656