### PR TITLE
WINDUPRULE-665 Disable links test temporary

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -306,6 +306,7 @@
                     <argLine>${arguments}</argLine>
                     <excludes>
                         <exclude>**/WindupRulesMultipleTests*</exclude>
+                        <exclude>**/WindupRulesLinksTest*</exclude>
                     </excludes>
                	</configuration>
             </plugin>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-665

Temporary disabling the test since a lot of PRs for rules are coming and without a working solution in #494, we have to disable this check to have a more stable build to know if the tests are fine with each PR and each nightly build accepting the risk of having some broken link.