### PR TITLE
WINDUP-2937 Added sorting to have a deterministic ordering in hint's message

### DIFF
--- a/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
+++ b/rules-reviewed/camel3/camel2/tests/xml-moved-components.windup.test.xml
@@ -12,7 +12,7 @@
                 <when>
                     <not>
                         <iterable-filter size="1">
-                            <hint-exists message="`*camel-rest`, `camel-dataformat`, `camel-direct-vm`, `camel-log`, `camel-direct`, `camel-validator`, `camel-language`, `camel-zip-deflater`, `camel-scheduler`, `camel-timer`, `camel-ref`, `camel-file`, `camel-vm`, `camel-stub`, `camel-xslt`, `camel-controlbus`, `camel-dataset`, `camel-bean`, `camel-browse.*`" />
+                            <hint-exists message="`*camel-bean`, `camel-browse`, `camel-controlbus`, `camel-dataformat`, `camel-dataset`, `camel-direct-vm`, `camel-direct`, `camel-file`, `camel-language`, `camel-log`, `camel-ref`, `camel-rest`, `camel-scheduler`, `camel-stub`, `camel-timer`, `camel-validator`, `camel-vm`, `camel-xslt`, `camel-zip-deflater.*`" />
                         </iterable-filter>
                     </not>
                 </when>

--- a/rules-reviewed/camel3/camel2/xml-moved-components.windup.groovy
+++ b/rules-reviewed/camel3/camel2/xml-moved-components.windup.groovy
@@ -131,7 +131,7 @@ ruleSet("xml-moved-components-groovy")
 
                 if (usedComponents.size() > 0) {
                     String components = usedComponents.stream()
-                            .map { component -> "`camel-$component`" }.toArray().toString()
+                            .map { component -> "`camel-$component`" }.sorted().toArray().toString()
                     ((Hint) Hint.titled("Modularization of camel-core")
                             .withText(" $components components were moved out of `camel-core` to separate artifacts. Maven users of Apache Camel can keep using the dependency `camel-core`" +
                                     "which has transitive dependencies on all of its modules, except for `camel-main`" +


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-2937

After having changed the Groovy-all extensions version in https://github.com/windup/windup/pull/1403, the order of the Camel components in the hint's message changed.
So the PR introduces sorting of values to have them always in the same order and hence safely testable.