### PR TITLE
WINDUPRULE-717 Quarkus Release 1.12 - Mailer

### DIFF
--- a/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
@@ -17,18 +17,21 @@
     <rules>
         <rule id="quarkus1-12-mailer-00000">
             <when>
-                <javaclass references="io.quarkus.mailer.MailTemplate.MailTemplateInstance" >
-                    <!--<location>METHOD_CALL</location>-->
+                <javaclass references="io.quarkus.mailer.MailTemplate.MailTemplateInstance" as="mailtemplateinstance">
+                    <location>IMPORT</location>
                 </javaclass>
+                <filecontent filename="{*}.java" pattern=".send(" from="mailtemplateinstance" as="sendmethod"/>
             </when>
-            <perform>
-                <hint title="Mailer - change to returned type" effort="1" category-id="potential">
-                        <message>The `MailTemplateInstance` now returns a `Uni` instead of `CompletionStage`. 
-                            To convert a `Uni` to a `CompletionStage`, call `.subscribeAsCompletionStage()`.
-                        </message>
-                        <link title="Quarkus - Migration Guide 1.12" href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12#mailer" />
-                </hint>
-            </perform>
+                <perform>
+                    <iteration over="sendmethod">
+                        <hint title="Mailer - change to returned type" effort="1" category-id="potential">
+                            <message>The `MailTemplateInstance` now returns a `Uni&lt;Void&gt;` instead of `CompletionStage&lt;Void&gt;`. 
+                                To convert a `Uni` to a `CompletionStage`, call `.subscribeAsCompletionStage()`.
+                            </message>
+                            <link title="Quarkus - Migration Guide 1.12" href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12#mailer" />
+                        </hint>
+                    </iteration>
+                </perform>
         </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
@@ -20,7 +20,7 @@
                 <javaclass references="io.quarkus.mailer.MailTemplate.MailTemplateInstance" as="mailtemplateinstance">
                     <location>IMPORT</location>
                 </javaclass>
-                <filecontent filename="{*}.java" pattern=".send(" from="mailtemplateinstance" as="sendmethod"/>
+                <filecontent pattern=".send(" from="mailtemplateinstance" as="sendmethod"/>
             </when>
                 <perform>
                     <iteration over="sendmethod">

--- a/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
@@ -10,7 +10,7 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
             <addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final" />
         </dependencies>
-        <!-- The major version is implied by the target, the minor is reflected in the verionRange -->
+        <!-- The major version is implied by the target, the minor is reflected in the versionRange -->
         <sourceTechnology id="quarkus1" versionRange="(,11]"/>
         <targetTechnology id="quarkus1" versionRange="[12,)"/>
     </metadata>

--- a/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="quarkus1-12-mailer"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset gives hints for upgrading to Quarkus 1.12 for applications that call io.quarkus.mailer.MailTemplate.MailTemplateInstance.send() 
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final" />
+        </dependencies>
+        <!-- The major version is implied by the target, the minor is reflected in the verionRange -->
+        <sourceTechnology id="quarkus1" versionRange="(,11]"/>
+        <targetTechnology id="quarkus1" versionRange="[12,)"/>
+    </metadata>
+    <rules>
+        <rule id="quarkus1-12-mailer-00000">
+            <when>
+                <javaclass references="io.quarkus.mailer.MailTemplate.MailTemplateInstance" >
+                    <!--<location>METHOD_CALL</location>-->
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="Mailer - change to returned type" effort="1" category-id="potential">
+                        <message>The `MailTemplateInstance` now returns a `Uni` instead of `CompletionStage`. 
+                            To convert a `Uni` to a `CompletionStage`, call `.subscribeAsCompletionStage()`.
+                        </message>
+                        <link title="Quarkus - Migration Guide 1.12" href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12#mailer" />
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/quarkus1-12-mailer.windup.xml
@@ -25,7 +25,7 @@
                 <perform>
                     <iteration over="sendmethod">
                         <hint title="Mailer - change to returned type" effort="1" category-id="potential">
-                            <message>The `MailTemplateInstance` now returns a `Uni&lt;Void&gt;` instead of `CompletionStage&lt;Void&gt;`. 
+                            <message>The `MailTemplateInstance` now returns a `Uni&lt;Void&gt;` instead of `CompletionStage&lt;Void&gt;`.  
                                 To convert a `Uni` to a `CompletionStage`, call `.subscribeAsCompletionStage()`.
                             </message>
                             <link title="Quarkus - Migration Guide 1.12" href="https://github.com/quarkusio/quarkus/wiki/Migration-Guide-1.12#mailer" />

--- a/rules-reviewed/quarkus1/quarkus1-11/tests/data/MailerResource.java
+++ b/rules-reviewed/quarkus1/quarkus1-11/tests/data/MailerResource.java
@@ -31,9 +31,6 @@ public class MailerResource {
             @Valid @Email @QueryParam("email") String email,
             @Valid @NotBlank @QueryParam("name") String name) {
         
-                MailTemplate.MailTemplateInstance.send();
-                MailTemplateInstance.send();
-                MailTemplate.of();
                 return Templates.hello(name)
                 .to(email)
                 .subject("Ahoy " + name + "!")

--- a/rules-reviewed/quarkus1/quarkus1-11/tests/data/MailerResource.java
+++ b/rules-reviewed/quarkus1/quarkus1-11/tests/data/MailerResource.java
@@ -1,0 +1,50 @@
+package org.acme.getting.started;
+
+import javax.inject.Inject;
+import javax.validation.Valid;
+import javax.validation.constraints.Email;
+import javax.validation.constraints.NotBlank;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import io.quarkus.mailer.MailTemplate;
+import io.quarkus.mailer.MailTemplate.MailTemplateInstance;
+import io.quarkus.mailer.Mailer;
+import io.quarkus.mailer.reactive.ReactiveMailer;
+import io.quarkus.qute.api.CheckedTemplate;
+import io.smallrye.mutiny.Uni;
+import org.jboss.resteasy.annotations.jaxrs.PathParam;
+
+import java.util.concurrent.CompletionStage;
+
+@Path("/mail")
+public class MailerResource {
+
+    
+    @GET
+    @Produces(MediaType.TEXT_PLAIN)
+    public CompletionStage<Response> greeting(
+            @Valid @Email @QueryParam("email") String email,
+            @Valid @NotBlank @QueryParam("name") String name) {
+        
+                MailTemplate.MailTemplateInstance.send();
+                MailTemplateInstance.send();
+                MailTemplate.of();
+                return Templates.hello(name)
+                .to(email)
+                .subject("Ahoy " + name + "!")
+                .send()
+                .thenApply(x -> Response.accepted().build());
+    }
+
+    @CheckedTemplate
+    static class Templates {
+        public static native MailTemplate.MailTemplateInstance hello(String name);
+    }
+
+
+}

--- a/rules-reviewed/quarkus1/quarkus1-11/tests/quarkus1-12-mailer.windup.test.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/tests/quarkus1-12-mailer.windup.test.xml
@@ -10,9 +10,9 @@
             <rule id="quarkus1-12-mailer-00000-test">
                 <when>
                     <not>
-                        <!-- <iterable-filter size="2"> -->
+                        <iterable-filter size="1">
                             <hint-exists message="The `MailTemplateInstance` now returns*"/>
-                        <!-- </iterable-filter> --> 
+                        </iterable-filter> 
                     </not>
                 </when>
                 <perform>

--- a/rules-reviewed/quarkus1/quarkus1-11/tests/quarkus1-12-mailer.windup.test.xml
+++ b/rules-reviewed/quarkus1/quarkus1-11/tests/quarkus1-12-mailer.windup.test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruletest id="quarkus1-12-mailer-tests"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data</testDataPath>
+    <rulePath>../quarkus1-12-mailer.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="quarkus1-12-mailer-00000-test">
+                <when>
+                    <not>
+                        <!-- <iterable-filter size="2"> -->
+                            <hint-exists message="The `MailTemplateInstance` now returns*"/>
+                        <!-- </iterable-filter> --> 
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[quarkus1-12-mailer-00000] The mailer hint was not found!" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
This PR is incomplete. It has been created to illustrate a problem that WINDUP has identifying a method call. the rule is trying to identify the MailTemplateInstance.send() method. It has revealed a generic problem with WINDUP in that it can't deal with the fluent API.
The message text should contain void (in diagonal brackets) however that seems to be incompatible with writing a rule in XML so the final version of this rule may have to be groovy. 