### PR TITLE
[WINDUPRULE-738] (thorntail -> eap xp2+) replace thorntail boms

### DIFF
--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="replace_thorntail_boms"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis of Maven built applications that use Thorntail BOMs to manage dependencies,
+            which should be replaced by JBoss EAP XP and/or JBoss EAP BOMs, when migrating to JBoss EAP XP.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+            <addon id="org.jboss.windup.rules,windup-rules-xml,3.0.0.Final" />
+        </dependencies>
+        <targetTechnology id="eapxp" versionRange="[2,)" />
+    </metadata>
+    <rules>
+        <!-- https://issues.jboss.org/browse/WINDUPRULE-738 -->
+        <rule id="replace_thorntail_boms-1">
+            <when>
+                <xmlfile matches="/m:project/m:dependencyManagement/m:dependencies/m:dependency[m:groupId/text() = 'io.thorntail' and m:artifactId/text() = 'bom']" in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <hint title="Replace Thorntail BOMs - io.thorntail:bom" effort="1" category-id="potential">
+                    <message>If you migrate your application to JBoss EAP XP 2.0 (or later), and want to ensure its Maven building, running or testing works as expected, replace Thorntail BOM `io.thorntail:bom` with JBoss EAP XP MicroProfile BOM and/or JBoss EAP Jakarta EE BOM.</message>
+                    <link title="Red Hat JBoss EAP XP Migration Guide: Thorntail Application Maven Project Migration" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/red_hat_jboss_eap_xp_2.0.0_migration_guide/thorntail-application-maven-project-migration_default#migrating-a-thorntail-application-maven-project-into-eap-xp_default"/>
+                    <tag>Thorntail</tag>
+                </hint>
+            </perform>
+        </rule>
+        <rule id="replace_thorntail_boms-2">
+            <when>
+                <xmlfile matches="/m:project/m:dependencyManagement/m:dependencies/m:dependency[m:groupId/text() = 'io.thorntail' and m:artifactId/text() = 'bom-certified']" in="pom.xml">
+                    <namespace prefix="m" uri="http://maven.apache.org/POM/4.0.0"/>
+                </xmlfile>
+            </when>
+            <perform>
+                <hint title="Replace Thorntail BOMs - io.thorntail:bom-certified" effort="1" category-id="potential">
+                    <message>If you migrate your application to JBoss EAP XP 2.0 (or later), and want to ensure its Maven building, running or testing works as expected, replace Thorntail BOM `io.thorntail:bom-certified` with JBoss EAP XP MicroProfile BOM and/or JBoss EAP Jakarta EE BOM.</message>
+                    <link title="Red Hat JBoss EAP XP Migration Guide: Thorntail Application Maven Project Migration" href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.3/html/red_hat_jboss_eap_xp_2.0.0_migration_guide/thorntail-application-maven-project-migration_default#migrating-a-thorntail-application-maven-project-into-eap-xp_default"/>
+                    <tag>Thorntail</tag>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/eapxp/thorntail/tests/data/data-replace_thorntail_boms/pom.xml
+++ b/rules-reviewed/eapxp/thorntail/tests/data/data-replace_thorntail_boms/pom.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.jboss.windup.rules.test</groupId>
+        <artifactId>windup-rulesets-test-pom</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>eapxp-thorntail-replace_thorntail_boms</artifactId>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>io.thorntail</groupId>
+                <artifactId>bom</artifactId>
+                <version>2.7.1.Final-redhat-00001</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
+                <groupId>io.thorntail</groupId>
+                <artifactId>bom-certified</artifactId>
+                <version>2.7.1.Final-redhat-00001</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+</project>

--- a/rules-reviewed/eapxp/thorntail/tests/replace_thorntail_boms.mta.test.xml
+++ b/rules-reviewed/eapxp/thorntail/tests/replace_thorntail_boms.mta.test.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<ruletest xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          id="replace_thorntail_boms-test" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/data-replace_thorntail_boms/</testDataPath>
+    <rulePath>../replace_thorntail_boms.mta.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="replace_thorntail_boms-1-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="If you migrate your application to JBoss EAP XP 2.0 \(or later\), and want to ensure its Maven building, running or testing works as expected, replace Thorntail BOM `io.thorntail:bom` with JBoss EAP XP MicroProfile BOM and/or JBoss EAP Jakarta EE BOM." />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="No reference to Thorntail BOM `io.thorntail:bom` found in pom.xml" />
+                </perform>
+            </rule>
+            <rule id="replace_thorntail_boms-2-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="If you migrate your application to JBoss EAP XP 2.0 \(or later\), and want to ensure its Maven building, running or testing works as expected, replace Thorntail BOM `io.thorntail:bom-certified` with JBoss EAP XP MicroProfile BOM and/or JBoss EAP Jakarta EE BOM." />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="No reference to Thorntail BOM `io.thorntail:bom-certified` found in pom.xml" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
Apply again the changes from https://github.com/windup/windup-rulesets/pull/549 (reverted in https://github.com/windup/windup-rulesets/pull/550) for https://issues.redhat.com/browse/WINDUPRULE-738