### PR TITLE
WINDUPRULE-754 java.lang.Thread.stop(java.lang.Throwable) has been removed

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="java-removals"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis with respect to API removals between OpenJDK 8 and 11.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="openjdk" versionRange="[8,)"/>
+        <targetTechnology id="openjdk" versionRange="[11,)"/>
+    </metadata>
+    <rules>
+        <rule id="java-removals-00000">
+            <when>
+                <javaclass references="java.lang.Thread.stop({.+})">
+                    <location>METHOD_CALL</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="The `java.lang.Thread.stop(Throwable)` method has been removed" effort="3" category-id="mandatory">
+                    <message>
+                        The `java.lang.Thread.stop(Throwable)` method has been removed, as it is dangerous for a thread to not only be able to directly stop another thread, but with an exception it may not expect. Instead, the thread should be notified to stop using a shared variable or `interrupt()`.
+                    </message>
+                    <link title="Java Thread Primitive Deprecation" href="https://docs.oracle.com/javase/7/docs/technotes/guides/concurrency/threadPrimitiveDeprecation.html"/>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ThreadStop.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ThreadStop.java
@@ -1,0 +1,15 @@
+public class ThreadStop {
+
+    public static void main(String[] args) {
+	Thread t1 = new Thread(new Runnable() {
+		@Override
+		public void run() {
+		    while (true) {
+			System.out.println("Test thread running.");
+		    }
+		}
+	    }, "Test Thread");
+	t1.start();
+	t1.stop(new ArrayIndexOutOfBoundsException());
+    }
+}

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruletest id="java-removals-tests"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/java-removals</testDataPath>
+    <rulePath>../java-removals.windup.xml</rulePath>
+    <ruleset>
+      <rules>
+        <rule id="java-removals-00000-test">
+          <when>
+	    <not>
+	      <iterable-filter size="1">
+		<hint-exists message="The `java.lang.Thread.stop(Throwable)*" />
+	      </iterable-filter>
+	    </not>
+          </when>
+          <perform>
+	    <fail message="[java-removals] `java.lang.Thread.stop(Throwable)` removal hint was not found."/>
+          </perform>
+        </rule>
+      </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
First attempt at a rule for the transition from OpenJDK 8 to 11.

See: https://issues.redhat.com/browse/WINDUPRULE-754

Rule was successfully tested locally:

~~~~
$ ${RHAMT_HOME}/bin/mta-cli --sourceMode --input \
rules-reviewed/openjdk11/openjdk8/tests/data --output /tmp/oj11-report \
--target openjdk:11
~~~~~

but testing via Maven failed with unrelated errors

~~~~
$ mvn -Dtest=WindupRulesMultipleTests -DrunTestsMatching=java-generic clean surefire-report:report 

org.jboss.arquillian.container.spi.client.container.DeploymentException: org.eclipse.aether.resolution.DependencyResolutionException: Failure to find org.jboss.windup.graph:windup-graph-impl:jar:5.1.5-SNAPSHOT in https://repo1.maven.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
Caused by: java.lang.RuntimeException: org.eclipse.aether.resolution.DependencyResolutionException: Failure to find org.jboss.windup.graph:windup-graph-impl:jar:5.1.5-SNAPSHOT in https://repo1.maven.org/maven2 was cached in the local repository, resolution will not be reattempted until the update interval of central has elapsed or updates are forced
~~~~