### PR TITLE
WINDUPRULE-772 OpenJDK8 to OpenJDK11 java.activation module removed

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/removed-javaee-modules.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/removed-javaee-modules.windup.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0"?>
+<ruleset xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="removed-javaee-modules"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis with respect to modules removed between OpenJDK 8 and 11.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <sourceTechnology id="openjdk" versionRange="[8,)"/>
+        <targetTechnology id="openjdk" versionRange="[11,)"/>
+    </metadata>
+    <rules>
+        <rule id="removed-javaee-modules-00000">
+            <when>
+            	<javaclass references="javax.activation{*}">
+            		<location>IMPORT</location>
+            	</javaclass>
+            </when>            
+            <perform>
+                <hint title="The java.activation (JAF) module has been removed from OpenJDK 11" effort="1" category-id="mandatory">
+                    <message>
+                        Add the `jakarta.activation` dependency to your application's `pom.xml`.&#xa;
+                        `&lt;groupId&gt;jakarta.activation&lt;/groupId&gt;`&#xa;
+                        `&lt;artifactId&gt;jakarta.activation&lt;/artifactId&gt;`
+                    </message>
+                    <link title="Removed Java EE modules" href="https://www.oracle.com/java/technologies/javase/11-relnote-issues.html#JDK-8190378"/>
+                </hint>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>
+

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/removed-javaee-modules/CompleteDukeApplication.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/removed-javaee-modules/CompleteDukeApplication.java
@@ -1,0 +1,30 @@
+package eu.agilejava.dukes;
+
+import javax.activation;
+import javax.annotation.*;
+import javax.batch.*;
+import javax.decorator;
+import javax.ejb.*;
+import javax.el;
+import javax.enterprise.*;
+import javax.faces.*;
+import javax.inject;
+import javax.interceptor;
+import javax.jms;
+import javax.json.*;
+import javax.jws.*;
+import javax.mail.*;
+import javax.persistence.*;
+import javax.resource.*;
+import javax.security.*;
+import javax.servlet.*;
+import javax.transaction;
+import javax.validation.*;
+import javax.websocket.*;
+import javax.ws.*;
+import javax.xml.*;
+
+
+@ApplicationPath("")
+public class CompleteDukeApplication extends Application {
+}

--- a/rules-reviewed/openjdk11/openjdk8/tests/removed-javaee-modules.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/removed-javaee-modules.windup.test.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<ruletest id="removed-javaee-modules"
+          xmlns="http://windup.jboss.org/schema/jboss-ruleset"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <testDataPath>data/removed-javaee-modules</testDataPath>
+    <rulePath>../removed-javaee-modules.windup.xml</rulePath>
+    <ruleset>
+      <rules>
+        <rule id="removed-javaee-modules-00000-test">
+          <when>
+	    <not>
+	      <iterable-filter size="1">
+		<hint-exists message="Add the `jakarta.activation` dependency to your application's `pom.xml`. *" />
+	      </iterable-filter>
+	    </not>
+          </when>
+          <perform>
+	    <fail message="removed-javaee-modules-00000-test - has failed"/>
+          </perform>
+        </rule>
+      </rules>
+    </ruleset>
+</ruletest>


### PR DESCRIPTION
Rule for identifying the `java.activation` module that has been removed in OpenJDK-11 