### PR TITLE
Added 'openjdk11' shortcut

### DIFF
--- a/rules-reviewed/openjdk11/openjdk11.windup.technologytransformer.xml
+++ b/rules-reviewed/openjdk11/openjdk11.windup.technologytransformer.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<technology-reference-transfomers xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <transform>
+        <sourceTechnology id="openjdk11"/>
+        <targetTechnology id="openjdk" versionRange="[11]"/>
+    </transform>
+</technology-reference-transfomers>
+


### PR DESCRIPTION
Building a CLI with this change, makes the CLI executed with `--listTargetTechnologies` command to print:
```shell
Available target technologies:
	camel
	cloud-readiness
	drools
	eap
	eap6
	eap7
	eapxp
	fsw
	fuse
	generate-quarkus
	hibernate
	hibernate-search
	jakarta-ee
	java-ee
	jbpm
	linux
	openjdk
	openjdk11
	quarkus
	quarkus1
	resteasy
	rhr

```
where `openjdk11` is available.