### PR TITLE
WINDUPRULE-775 java.annotation API removed

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/removed-javaee-modules.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/removed-javaee-modules.windup.xml
@@ -54,6 +54,23 @@
                 </hint>
             </perform>
         </rule>
+                <rule id="removed-javaee-modules-00020">
+            <when>
+            	<javaclass references="javax.annotation{*}">
+            		<location>IMPORT</location>
+            	</javaclass>
+            </when>            
+            <perform>
+                <hint title="The java.annotation (Common Annotations) module has been removed from OpenJDK 11" effort="1" category-id="mandatory">
+                    <message>
+                        Add the `jakarta.annotation` dependency to your application's `pom.xml`.&#xa;
+                        `&lt;groupId&gt;jakarta.annotation&lt;/groupId&gt;`&#xa;
+                        `&lt;artifactId&gt;jakarta.annotation-api&lt;/artifactId&gt;`
+                    </message>
+                    <link title="Removed Java EE modules" href="https://www.oracle.com/java/technologies/javase/11-relnote-issues.html#JDK-8190378"/>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>
 

--- a/rules-reviewed/openjdk11/openjdk8/tests/removed-javaee-modules.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/removed-javaee-modules.windup.test.xml
@@ -29,7 +29,19 @@
               <perform>
                   <fail message="removed-javaee-modules-00010-test - has failed"/>
               </perform>
-        </rule>
+          </rule>
+          <rule id="removed-javaee-modules-00020-test">
+              <when>
+                  <not>
+                      <iterable-filter size="1">
+                          <hint-exists message="Add the `jakarta.annotation` dependency to your application's `pom.xml`. *" />
+                      </iterable-filter>
+                  </not>
+              </when>
+              <perform>
+                  <fail message="removed-javaee-modules-00020-test - has failed"/>
+              </perform>
+          </rule>
       </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
New rule for the removal of the java.annotation api