### PR TITLE
Skip 'download-css' when not testing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -364,6 +364,7 @@
                 </executions>
                 <configuration>
                     <generateReports>false</generateReports>
+                    <skip>${skipTests}</skip>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
During the release, there was an ongoing outage on maven.repository.redhat.com that generated this failure:
```shell
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.5.1:site (download-css) on project windup-rulesets: SiteToolException: The site descriptor cannot be resolved from the repository: ArtifactResolutionException: Unable to locate site descriptor: Could not transfer artifact org.jboss:jboss-parent:xml:site_en:22 from/to redhat-ga-repository (https://maven.repository.redhat.com/ga/): Failed to transfer file: https://maven.repository.redhat.com/ga/org/jboss/jboss-parent/22/jboss-parent-22-site_en.xml. Return code is: 500 , ReasonPhrase:Internal Server Error.
```
Since tests were skipped, also the `download-css`, which is bounded to `test` phase, has been configured to be skipped when tests are skipped.