### PR TITLE
WINDUP-3277 OpenLiberty Dynamic Cache links fix

### DIFF
--- a/rules-reviewed/openliberty/websphere/liberty-websphere-unavailable-technologies.windup.xml
+++ b/rules-reviewed/openliberty/websphere/liberty-websphere-unavailable-technologies.windup.xml
@@ -109,9 +109,10 @@
  &lt;p&gt; This rule flags APIs from the &lt;code&gt;com.ibm.websphere.asynchbeans&lt;/code&gt; package. These APIs are not provided on Liberty and are marked as deprecated in WebSphere Application Server traditional V9.0. The WebSphere Asynchronous Beans API are replaced by JSR 236, Concurrency Utilities for Java EE. &lt;/p&gt; 
  &lt;p&gt; &lt;b&gt;Note:&lt;/b&gt; Concurrency Utilities for Java EE provides no replacement for the &lt;code&gt;com.ibm.websphere.asynchbeans.pool&lt;/code&gt; APIs. &lt;/p&gt;  
  &lt;p&gt; For information and examples about how to use Concurrency Utilities for Java EE instead of Asynchronous beans in WebSphere traditional, see &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=cord&amp;amp;product=was-nd-mp&amp;amp;topic=rasb_migrate_to_eeconcurrency" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=cord&amp;amp;product=was-nd-mp&amp;amp;topic=rasb_migrate_to_eeconcurrency'); return false;"&gt; Examples to migrate to EE Concurrency from Asynchronous beans and CommonJ&lt;/a&gt;. &lt;/p&gt; 
- &lt;p&gt; For information about the Concurrency Utilities for Java EE feature &lt;code&gt;concurrent-1.0&lt;/code&gt; in Liberty, see the &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-dist&amp;amp;topic=rwlp_feature_concurrent-1.0" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-dist&amp;amp;topic=rwlp_feature_concurrent-1.0'); return false;"&gt; Concurrency Utilities for Java EE 1.0&lt;/a&gt; documentation. &lt;/p&gt;  
+ &lt;p&gt; For information about the Concurrency Utilities for Java EE feature &lt;code&gt;concurrent-1.0&lt;/code&gt; in Liberty, see the link below   
 &lt;/div&gt;</message>
-                    <link href="https://www.ibm.com/docs/wamt?topic=rules-open-liberty-migration-in-windup" title="Open Liberty migration rules in Windup"/>
+            <link href="https://www.ibm.com/docs/en/was-liberty/nd?topic=features-concurrency-utilities-java-ee-10" title="Concurrency Utilities for Java EE 1.0"/>        
+            <link href="https://www.ibm.com/docs/wamt?topic=rules-open-liberty-migration-in-windup" title="Open Liberty migration rules in Windup"/>
                 </hint>
             </perform>
             <where param="AsyncBeansSchedulerRule_0_packages">
@@ -505,8 +506,9 @@
                     <message>&lt;div class="Text"&gt; 
  &lt;p&gt; The WebSphere Scheduler API was superseded by Enterprise JavaBeans Persistent Timers 3.2, which is enabled by the ejbPersistentTimer-3.2 Liberty feature. &lt;/p&gt; 
  &lt;p&gt; This rule flags references to the &lt;code&gt;com.ibm.websphere.scheduler&lt;/code&gt; package because it is not available on Liberty. &lt;/p&gt;  
- &lt;p&gt; For information about the Enterprise JavaBeans Persistent Timers feature, see the &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-dist&amp;amp;topic=rwlp_feature_ejbPersistentTimer-3.2" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-dist&amp;amp;topic=rwlp_feature_ejbPersistentTimer-3.2'); return false;"&gt; Enterprise JavaBeans Persistent Timers 3.2&lt;/a&gt; documentation. &lt;/p&gt;  
+ &lt;p&gt; For information about the Enterprise JavaBeans Persistent Timers feature, see the link below   
 &lt;/div&gt;</message>
+                    <link href="https://www.ibm.com/docs/en/was-liberty/nd?topic=features-enterprise-javabeans-persistent-timers-32" title="Enterprise JavaBeans Persistence Timers 3.2"/>    
                     <link href="https://www.ibm.com/docs/wamt?topic=rules-open-liberty-migration-in-windup" title="Open Liberty migration rules in Windup"/>
                 </hint>
             </perform>

--- a/rules-reviewed/openliberty/websphere/liberty-websphere-unavailable-technologies.windup.xml
+++ b/rules-reviewed/openliberty/websphere/liberty-websphere-unavailable-technologies.windup.xml
@@ -260,7 +260,6 @@
   &lt;li&gt;No cache replication&lt;/li&gt; 
   &lt;li&gt;Only the high-performance disk caching mode is supported with random and size eviction techniques&lt;/li&gt; 
   &lt;li&gt;There is no support for Web Services client and server side caching as well as portlet caching in the cachespec.xml file&lt;/li&gt; 
-  &lt;li&gt;Portlet caching and Web Services client and server side caching are not supported in the cachespec.xml file&lt;/li&gt; 
   &lt;li&gt;Servlet caching of SingleThreadModel servlets is not supported&lt;/li&gt; 
   &lt;li&gt;Defining cache configuration by using properties files is not supported for JAR files that contain only Enterprise JavaBeans&lt;/li&gt; 
   &lt;li&gt;Limiting the memory cache sizes in megabytes works only for 32-bit Java Virtual Machines&lt;/li&gt; 
@@ -286,10 +285,10 @@
  &lt;ul&gt; 
   &lt;li&gt; &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_restrict#rwlp_restrict__dynacache-restrict" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_restrict#rwlp_restrict__dynacache-restrict'); return false;"&gt; Liberty:Runtime environment known issues and restrictions&lt;/a&gt; &lt;/li&gt; 
   &lt;li&gt; &lt;a href="https://mediacenter.ibm.com/media/Dynamic+cache+in+Liberty/0_bnh3uidz" title="Opens a new window" onclick="javascript:helpWindow('https://mediacenter.ibm.com/media/Dynamic+cache+in+Liberty/0_bnh3uidz'); return false;"&gt; Dynamic cache in Liberty&lt;/a&gt; document &lt;/li&gt;
-  &lt;li&gt; &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_feature_distributedMap-1.0" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_feature_distributedMap-1.0'); return false;"&gt; Distributed Map interface for Dynamic Caching&lt;/a&gt; feature documentation &lt;/li&gt; 
-  &lt;li&gt; &lt;a href="http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_feature_webCache-1.0" title="Opens a new window" onclick="javascript:helpWindow('http://www14.software.ibm.com/webapp/wsbroker/redirect?version=phil&amp;amp;product=was-nd-mp&amp;amp;topic=rwlp_feature_webCache-1.0'); return false;"&gt; Web Response Cache&lt;/a&gt; feature documentation &lt;/li&gt; 
- &lt;/ul&gt; 
-&lt;/div&gt;</message>
+  &lt;/div&gt; 
+</message>
+                    <link href="https://www.ibm.com/docs/en/was-liberty/nd?topic=features-distributed-map-interface-dynamic-caching-10" title="Distributed Map interface for Dynamic Caching"/>
+                    <link href="https://www.ibm.com/docs/en/was-liberty/nd?topic=features-web-response-cache-10" title="Web Response Cache feature documentation "/>
                     <link href="https://www.ibm.com/docs/wamt?topic=rules-open-liberty-migration-in-windup" title="Open Liberty migration rules in Windup"/>
                 </hint>
             </perform>


### PR DESCRIPTION
This is a fix to correct a duplicate bullet point in the body of a message and replace 2 broken links.
I have added the new links as true rule link elements rather than hyperlinks embedded within the message element. 