### PR TITLE
WINDUPRULE-829 SB2Quarkus map health endpoint

### DIFF
--- a/rules-reviewed/quarkus/springboot/springboot-actuator-to-quarkus.windup.xml
+++ b/rules-reviewed/quarkus/springboot/springboot-actuator-to-quarkus.windup.xml
@@ -34,9 +34,31 @@
                         Replace the Spring Boot Actuator dependency with Quarkus Smallrye Health extension.  
                         It has to be replaced by `io.quarkus:quarkus-smallrye-health` artifact.
                     </message>
-                    <link title="Quarkus - Microprofile Health" href="https://quarkus.io/guides/microprofile-health"/>
+                    <link title="Quarkus - Smallrye Health" href="https://quarkus.io/guides/smallrye-health"/>
                 </hint>
             </perform>
+        </rule>
+        <rule id="springboot-actuator-to-quarkus-0200">
+            <when>
+                <filecontent filename="application{profile}.{extension}" pattern="management.endpoints.web.exposure.include{wildcard}health" />
+            </when>
+            <perform>
+                <hint title="Replace Spring Health endpoint mapping" effort="1" category-id="mandatory">
+                    <message>
+                        Replace `management.endpoints.web.exposure.include=health` with `quarkus.smallrye-health.root-path=/actuator/health`
+                    </message>
+                    <link title="Quarkus Guide - Smallrye Health" href="https://quarkus.io/guides/smallrye-health" />
+                </hint>
+            </perform>
+            <where param="profile">
+                <matches pattern=".*" />
+            </where>
+            <where param="extension">
+                <matches pattern="(properties|yml|yaml)" />
+            </where>
+            <where param="wildcard">
+                <matches pattern=".*" />
+            </where>
         </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/quarkus/springboot/tests/data/springboot-actuator/application.properties
+++ b/rules-reviewed/quarkus/springboot/tests/data/springboot-actuator/application.properties
@@ -1,0 +1,1 @@
+management.endpoints.web.exposure.include=prometheus,health

--- a/rules-reviewed/quarkus/springboot/tests/springboot-actuator-to-quarkus.windup.test.xml
+++ b/rules-reviewed/quarkus/springboot/tests/springboot-actuator-to-quarkus.windup.test.xml
@@ -21,6 +21,18 @@
                         <fail message="[springboot-actuator-to-quarkus-0100] Spring Boot Actuator Dependency artifact replaced by Quarkus artifact was not found!" />
                 </perform>
             </rule>
+            <rule id="springboot-actuator-to-quarkus-0200-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                             <hint-exists message="Replace `management.endpoints.web.exposure.include=health`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                        <fail message="[springboot-actuator-to-quarkus-0200] Spring Boot Actuator Configuration was not found" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
This is another properties based change that originates from https://github.com/RedHat-Middleware-Workshops/spring-to-quarkus-todo#migrate-data-source-properties. Please review that link to verify the change advised by the rule firing is appropriate.
