### PR TITLE
WINDUPRULE-826 SB2Quarkus Swagger and OpenAPI property settings

### DIFF
--- a/rules-reviewed/quarkus/springboot/springboot-properties-to-quarkus.windup.xml
+++ b/rules-reviewed/quarkus/springboot/springboot-properties-to-quarkus.windup.xml
@@ -114,5 +114,55 @@
                 <matches pattern="(properties|yml|yaml)" />
             </where>
         </rule>
+        <rule id="springboot-properties-to-quarkus-00005">
+            <when>
+                <filecontent filename="application{profile}.{extension}" pattern="springdoc.swagger-ui.path" />
+            </when>
+            <perform>
+                <hint title="Replace Spring Swagger endpoint mapping" effort="1" category-id="mandatory">
+                    <message>
+                        Replace `springdoc.swagger-ui.path` with `quarkus.swagger-ui.path`
+                        
+                        By adding `quarkus.swagger-ui.always-include=true` Quarkus will always expose the Swagger UI endpoint. 
+                        It is only exposed in Dev mode by default.
+                    </message>
+                    <link title="Quarkus Guide - using OpenAPI and Swagger" href="https://quarkus.io/guides/openapi-swaggerui" />
+                    <quickfix type="REPLACE" name="swagger-ui-replace">
+                        <replacement>quarkus.swagger-ui.path</replacement>
+                        <search>springdoc.swagger-ui.path</search>
+                    </quickfix>
+                </hint>
+            </perform>
+            <where param="profile">
+                <matches pattern=".*" />
+            </where>
+            <where param="extension">
+                <matches pattern="(properties|yml|yaml)" />
+            </where>
+        </rule>
+        <rule id="springboot-properties-to-quarkus-00006">
+            <when>
+                <filecontent filename="application{profile}.{extension}" pattern="springdoc.api-docs.path" />
+            </when>
+            <perform>
+                <hint title="Replace Spring OpenAPI endpoint mapping" effort="1" category-id="mandatory">
+                    <message>
+                        Replace `springdoc.api-docs.path` with `quarkus.smallrye-openapi.path`
+                        
+                    </message>
+                    <link title="Quarkus Guide - using OpenAPI and Swagger" href="https://quarkus.io/guides/openapi-swaggerui" />
+                    <quickfix type="REPLACE" name="openapi-replace">
+                        <replacement>quarkus.smallrye-openapi.path</replacement>
+                        <search>springdoc.api-docs.path</search>
+                    </quickfix>
+                </hint>
+            </perform>
+            <where param="profile">
+                <matches pattern=".*" />
+            </where>
+            <where param="extension">
+                <matches pattern="(properties|yml|yaml)" />
+            </where>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/quarkus/springboot/tests/data/springboot-properties/application.properties
+++ b/rules-reviewed/quarkus/springboot/tests/data/springboot-properties/application.properties
@@ -8,3 +8,5 @@ spring.messages.basename=messages/messages
 management.endpoints.web.exposure.include=*
 logging.level.org.springframework=INFO
 spring.resources.cache.cachecontrol.max-age=12h
+springdoc.swagger-ui.path=/swagger-ui
+springdoc.api-docs.path=/openapi

--- a/rules-reviewed/quarkus/springboot/tests/springboot-properties-to-quarkus.windup.test.xml
+++ b/rules-reviewed/quarkus/springboot/tests/springboot-properties-to-quarkus.windup.test.xml
@@ -69,6 +69,26 @@
                     <fail message="[springboot-properties-to-quarkus-00004-test] SpringBoot JPA Hibernate property rule failed!" />
                 </perform>
             </rule>
+            <rule id="springboot-properties-to-quarkus-00005-test">
+                <when>
+                    <not>
+                        <hint-exists message="Replace `springdoc.swagger-ui.path` with `quarkus.swagger-ui.path`*"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[springboot-properties-to-quarkus-00005-test] SpringBoot Swagger endpoint property rule failed!" />
+                </perform>
+            </rule>
+            <rule id="springboot-properties-to-quarkus-00006-test">
+                <when>
+                    <not>
+                        <hint-exists message="Replace `springdoc.api-docs.path` with `quarkus.smallrye-openapi.path`*"/>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[springboot-properties-to-quarkus-00006-test] SpringBoot OpenAPI endpoint property rule failed!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
This PR contains rules for WINDUPRULE-826 and WINDUPRULE-827
They are both very similar in that they are SB2Quarkus rules pertaining to properties for Swagger and Open API respectively.
These rules originate from this tutorial https://github.com/RedHat-Middleware-Workshops/spring-to-quarkus-todo#migrate-data-source-properties 