### PR TITLE
WINDUPRULE-798: AWT SecurityManager methods removed rule

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -62,5 +62,31 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="java-removals-00040">
+            <when>
+                <javaclass references="java.lang.SecurityManager.{method-name}({*})"></javaclass>
+            </when>
+            <perform>
+                <hint title="AWT SecurityManager method java.lang.SecurityManager.{method-name} has been removed in Java 11" effort="1" category-id="mandatory">
+                    <message>
+                        Due to modularisation, the methods java.lang.SecurityManager.checkAwtEventQueueAccess(),
+                        java.lang.SecurityManager.checkSystemClipboardAccess() and
+                        java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object)
+                        have been removed, so that the core SecurityManager class does not depend on the AWT stack.
+
+                        Replace with a call to java.lang.SecurityManager.checkPermission(java.security.Permission) as follows:
+
+                        java.lang.SecurityManager.checkAwtEventQueueAccess() --> java.lang.SecurityManager.checkPermission(new AWTPermission("accessEventQueue"))
+                        java.lang.SecurityManager.checkSystemClipboardAccess() --> java.lang.SecurityManager.checkPermission(new AWTPermission("accessClipboard"))
+                        java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object) --> java.lang.SecurityManager.checkPermission(new AWTPermission("showWindowWithoutWarningBanner"))
+                    </message>
+                    <link title="Java 11 SecurityManager api" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/SecurityManager.html"/>
+                    <link title="Java 11 AWTPermission api" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/AWTPermission.html"/>
+                </hint>
+            </perform>
+            <where param="method-name">
+               <matches pattern="(checkAwtEventQueueAccess|checkSystemClipboardAccess|checkTopLevelWindow)"/>
+            </where>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -86,16 +86,16 @@
             <perform>
                 <hint title="AWT SecurityManager method java.lang.SecurityManager.{method-name} has been removed in Java 11" effort="1" category-id="mandatory">
                     <message>
-                        Due to modularisation, the methods java.lang.SecurityManager.checkAwtEventQueueAccess(),
-                        java.lang.SecurityManager.checkSystemClipboardAccess() and
-                        java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object)
+                        Due to modularisation, the methods `java.lang.SecurityManager.checkAwtEventQueueAccess()`,
+                        `java.lang.SecurityManager.checkSystemClipboardAccess()` and
+                        `java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object)`
                         have been removed, so that the core SecurityManager class does not depend on the AWT stack.
 
-                        Replace with a call to java.lang.SecurityManager.checkPermission(java.security.Permission) as follows:
+                        Replace with a call to `java.lang.SecurityManager.checkPermission(java.security.Permission)` as follows:
 
-                        java.lang.SecurityManager.checkAwtEventQueueAccess() --> java.lang.SecurityManager.checkPermission(new AWTPermission("accessEventQueue"))
-                        java.lang.SecurityManager.checkSystemClipboardAccess() --> java.lang.SecurityManager.checkPermission(new AWTPermission("accessClipboard"))
-                        java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object) --> java.lang.SecurityManager.checkPermission(new AWTPermission("showWindowWithoutWarningBanner"))
+                        `java.lang.SecurityManager.checkAwtEventQueueAccess()` --> `java.lang.SecurityManager.checkPermission(new AWTPermission("accessEventQueue"))`
+                        `java.lang.SecurityManager.checkSystemClipboardAccess()` --> `java.lang.SecurityManager.checkPermission(new AWTPermission("accessClipboard"))`
+                        `java.lang.SecurityManager.checkTopLevelWindow(java.lang.Object) --> java.lang.SecurityManager.checkPermission(new AWTPermission("showWindowWithoutWarningBanner"))`
                     </message>
                     <link title="Java 11 SecurityManager api" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/SecurityManager.html"/>
                     <link title="Java 11 AWTPermission api" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.desktop/java/awt/AWTPermission.html"/>

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/AWTSecurityManagement.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/AWTSecurityManagement.java
@@ -1,0 +1,15 @@
+
+import java.lang.SecurityManager
+
+
+
+public class AWTSecurityManagement {
+    public boolean checkAWTSecurityPermissions()
+    {
+        SecurityManager security = System.getSecurityManager();
+
+        return security.checkAwtEventQueueAccess() &&
+                security.checkSystemClipboardAccess() &&
+                security.checkTopLevelWindow(new Object());
+    }
+}

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -42,7 +42,7 @@
 	          <fail message="[java-removals] `java-removals-00020-test failed"/>
           </perform>
         </rule>
-        rule id="java-removals-00030-test">
+        <rule id="java-removals-00030-test">
               <when>
                   <not>
                       <iterable-filter size="2">

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -58,7 +58,7 @@
               <when>
                   <not>
                       <iterable-filter size="3">
-                          <hint-exists message="Due to modularisation, the methods java.lang.SecurityManager.checkAwtEventQueueAccess()" />
+                          <hint-exists message="Due to modularisation, the methods `java.lang.SecurityManager.checkAwtEventQueueAccess()`*" />
                       </iterable-filter>
                   </not>
               </when>

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -42,6 +42,18 @@
 	          <fail message="[java-removals] `java-removals-00020-test failed"/>
           </perform>
         </rule>
+          <rule id="java-removals-00040-test">
+              <when>
+                  <not>
+                      <iterable-filter size="3">
+                          <hint-exists message="Due to modularisation, the methods java.lang.SecurityManager.checkAwtEventQueueAccess()" />
+                      </iterable-filter>
+                  </not>
+              </when>
+              <perform>
+                  <fail message="[java-removals] `java-removals-00040-test failed"/>
+              </perform>
+          </rule>
       </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-798