### PR TITLE
[WINDUPRULE-[797, 799]] Implement rules for checkMemberAccess method in SecurityManager and runFinalizersOnExit methods

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -194,6 +194,26 @@
                 <matches pattern="(Encoder|Decoder)"/>
             </where>
         </rule>
+        <rule id="java-removals-00130">
+            <when>
+                <or>
+                    <javaclass references="java.lang.System.runFinalizersOnExit({*})"/>
+                    <javaclass references="java.lang.Runtime.runFinalizersOnExit({*})"/>
+                </or>
+            </when>
+            <perform>
+                <hint title="The `runFinalizersOnExit` methods have been removed" effort="1" category-id="mandatory">
+                    <message>
+                        The `java.lang.System.runFinalizersOnExit(boolean value)` and `java.lang.Runtime.runFinalizersOnExit(boolean value)`
+                        have been removed as they are regarded as inherently unsafe. Running finalizers on exit was disabled by default
+                        and enabling it could result in finalizers being called on live objects which are still being manipulated by other threads.
+
+                        Remove these method calls.
+                    </message>
+                    <link title="JDK 11 removed APIs" href="https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-4B613B7E-B150-4D0A-835C-2393C60BE1F8"/>
+                </hint>
+            </perform>
+        </rule>
         <rule id="java-removals-00050">
             <when>
                 <javaclass references="java.util.logging.LogManager.addPropertyChangeListener({*})"/>

--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -113,6 +113,22 @@
                <matches pattern="(checkAwtEventQueueAccess|checkSystemClipboardAccess|checkTopLevelWindow)"/>
             </where>
         </rule>
+        <rule id="java-removals-00041">
+            <when>
+                <javaclass references="java.lang.SecurityManager.checkMemberAccess({*})"/>
+            </when>
+            <perform>
+                <hint title="SecurityManager method java.lang.SecurityManager.checkMemberAccess has been removed" effort="1" category-id="mandatory">
+                    <message>
+                        The implementation of `java.lang.SecurityManager.checkMemberAccess(java.lang.Class, int)` relies on an assumption
+                        that the caller is at a stack depth of 4, which is not something that can be enforced, making the code error-prone.
+
+                        Replace with a call to `java.lang.SecurityManager.checkPermission(new RuntimePermission("accessDeclaredMembers"))`.
+                    </message>
+                    <link title="Java 11 SecurityManager api" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/SecurityManager.html"/>
+                </hint>
+            </perform>
+        </rule>
         <rule id="java-removals-00100">
             <when>
                 <or>

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/AWTSecurityManagement.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/AWTSecurityManagement.java
@@ -6,10 +6,12 @@ import java.lang.SecurityManager
 public class AWTSecurityManagement {
     public boolean checkAWTSecurityPermissions()
     {
-        SecurityManager security = System.getSecurityManager();
+        SecurityManager securityManager = System.getSecurityManager();
 
-        return security.checkAwtEventQueueAccess() &&
-                security.checkSystemClipboardAccess() &&
-                security.checkTopLevelWindow(new Object());
+        securityManager.checkMemberAccess(AWTSecurityManagement.class, 3);
+
+        return securityManager.checkAwtEventQueueAccess() &&
+                securityManager.checkSystemClipboardAccess() &&
+                securityManager.checkTopLevelWindow(new Object());
     }
 }

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ThreadStop.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ThreadStop.java
@@ -1,16 +1,19 @@
 public class ThreadStop {
 
     public static void main(String[] args) {
-	Thread t1 = new Thread(new Runnable() {
-		@Override
-		public void run() {
-		    while (true) {
-			System.out.println("Test thread running.");
-		    }
-		}
-	    }, "Test Thread");
-	t1.start();
-	t1.stop(new ArrayIndexOutOfBoundsException());
-	t1.destroy();
+        System.runFinalizersOnExit(true);
+        Runtime.runFinalizersOnExit(true);
+
+        Thread t1 = new Thread(new Runnable() {
+            @Override
+            public void run() {
+                while (true) {
+                    System.out.println("Test thread running.");
+                }
+            }
+        }, "Test Thread");
+        t1.start();
+        t1.stop(new ArrayIndexOutOfBoundsException());
+        t1.destroy();
     }
 }

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -44,7 +44,6 @@
                     <fail message="[java-removals] `java-removals-00020-test failed"/>
                 </perform>
             </rule>
-
             <rule id="java-removals-00030-test">
                 <when>
                     <not>
@@ -55,6 +54,30 @@
                 </when>
                 <perform>
                     <fail message="[java-removals] `java-removals-00030-test failed"/>
+                </perform>
+            </rule>
+            <rule id="java-removals-00040-test">
+                <when>
+                    <not>
+                        <iterable-filter size="3">
+                            <hint-exists message="Due to modularisation, the methods `java.lang.SecurityManager.checkAwtEventQueueAccess()`*" />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-removals] `java-removals-00040-test failed"/>
+                </perform>
+            </rule>
+            <rule id="java-removals-00041-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="The implementation of `java.lang.SecurityManager.checkMemberAccess*"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-removals-00041-test] Could not find hint"/>
                 </perform>
             </rule>
             <rule id="java-removals-00050-test">

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -128,6 +128,18 @@
                     <fail message="[java-removals] sun.misc.BASE64Decoder hints not found"/>
                 </perform>
             </rule>
+            <rule id="java-removals-00130-test">
+                <when>
+                    <not>
+                        <iterable-filter size="2">
+                            <hint-exists message="The `java.lang.System.runFinalizersOnExit"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-removals-00130-test] Could not find hint"/>
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
See [https://issues.redhat.com/browse/WINDUPRULE-799](https://issues.redhat.com/browse/WINDUPRULE-799) and [https://issues.redhat.com/browse/WINDUPRULE-797](https://issues.redhat.com/browse/WINDUPRULE-797).