### PR TITLE
WINDUPRULE-788 - ComponentPeer removal rules

### DIFF
--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -261,8 +261,8 @@
                             The `java.awt.Font.getPeer()` and `java.awt.Component.getPeer()` methods have been removed.  
                             The `java.awt.peer` and `java.awt.dnd.peer` are no longer accessible and are considered
                             internal implementation details, the API may be removed without notice or changed in non
-                            compatible ways.  Methods exposing this API, such as `java.awt.Font.getPeer()`
-                            have been removed since JDK 9.  
+                            compatible ways.  
+                            Methods exposing this API, such as `java.awt.Font.getPeer()` have been removed since JDK 9.     
                             Since Font rendering is platform independent, there are no substitutes for this method.
                         </message>              
                     <link title="java.awt.peer Not Accessible" href="https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-0C350BAB-F2C8-409E-AD3E-63831C684A55"/>

--- a/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -129,6 +129,36 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="java-removals-00050">
+            <when>
+                <javaclass references="java.util.logging.LogManager.addPropertyChangeListener({*})"/>
+            </when>
+            <perform>
+                <hint title="The java.util.logging.LogManager.addPropertyChangeListener() method was removed in Java 9" effort="1" category-id="mandatory">
+                    <message>
+                        `java.util.logging.LogManager.addPropertyChangeListener()` method was removed in Java 9.
+                        In order to listen to property change events, please consider overriding the `java.util.logging.LogManager.readConfiguration` methods,
+                        which previously triggered property change events for the registered listeners.
+                    </message>
+                    <link href="https://docs.oracle.com/en/java/javase/16/migrate/removed-apis.html#GUID-B96BD00F-12A4-493A-9907-2FFE8DA6748C" title="APIs removed in JDK 9"/>
+                </hint>
+            </perform>
+        </rule>
+        <rule id="java-removals-00060">
+            <when>
+                <javaclass references="java.util.logging.LogManager.removePropertyChangeListener({*})"/>
+            </when>
+            <perform>
+                <hint title="The java.util.logging.LogManager.removePropertyChangeListener() method was removed in Java 9" effort="1" category-id="mandatory">
+                    <message>
+                        `java.util.logging.LogManager.removePropertyChangeListener()` method was removed in Java 9.
+                        In order to listen to property change events, please consider overriding the `java.util.logging.LogManager.readConfiguration` methods,
+                        which previously triggered property change events for the registered listeners.
+                    </message>
+                    <link href="https://docs.oracle.com/en/java/javase/16/migrate/removed-apis.html#GUID-B96BD00F-12A4-493A-9907-2FFE8DA6748C" title="APIs removed in JDK 9"/>
+                </hint>
+            </perform>
+        </rule>
         <rule id="java-removals-00100">
             <when>
                 <or>
@@ -214,37 +244,32 @@
                 </hint>
             </perform>
         </rule>
-        <rule id="java-removals-00050">
-            <when>
-                <javaclass references="java.util.logging.LogManager.addPropertyChangeListener({*})"/>
-            </when>
-            <perform>
-                <hint title="The java.util.logging.LogManager.addPropertyChangeListener() method was removed in Java 9" effort="1" category-id="mandatory">
-                    <message>
-                        `java.util.logging.LogManager.addPropertyChangeListener()` method was removed in Java 9.
-                        In order to listen to property change events, please substitute `java.util.logging.LogManager.addPropertyChangeListener()` with `java.util.logging.LogManager.addConfigurationListener(Runnable)`,
-                        which will be invoked at the end of both `readConfiguration()` and `updateConfiguration()` methods.
-                    </message>
-                    <link href="https://docs.oracle.com/en/java/javase/16/migrate/removed-apis.html#GUID-B96BD00F-12A4-493A-9907-2FFE8DA6748C" title="APIs removed in JDK 9"/>
-                </hint>
-            </perform>
-        </rule>
-        <rule id="java-removals-00060">
-            <when>
-                <javaclass references="java.util.logging.LogManager.removePropertyChangeListener({*})"/>
-            </when>
-            <perform>
-                <hint title="The java.util.logging.LogManager.removePropertyChangeListener() method was removed in Java 9" effort="1" category-id="mandatory">
-                    <message>
-                        `java.util.logging.LogManager.removePropertyChangeListener()` method was removed in Java 9.
-                        In order to listen to property change events, please substitute `java.util.logging.LogManager.removePropertyChangeListener()` with  `java.util.logging.LogManager.removeConfigurationListener(Runnable)`,
-                        which will be invoked at the end of both `readConfiguration()` and `updateConfiguration()` methods.
-                    </message>
-                    <link href="https://docs.oracle.com/en/java/javase/16/migrate/removed-apis.html#GUID-B96BD00F-12A4-493A-9907-2FFE8DA6748C" title="APIs removed in JDK 9"/>
-                </hint>
-            </perform>
-        </rule>
         <rule id="java-removals-00140">
+            <when>
+                <or>
+                    <javaclass references="java.awt.Font.getPeer({*})">
+                        <location>METHOD_CALL</location> 
+                    </javaclass>
+                    <javaclass references="java.awt.Component.getPeer({*})">
+                        <location>METHOD_CALL</location> 
+                    </javaclass>
+                </or>
+            </when>
+                <perform>
+                    <hint title="The `java.awt.Font.getPeer()` and `java.awt.Component.getPeer()` methods have been removed" effort="3" category-id="mandatory">
+                        <message>
+                            The `java.awt.Font.getPeer()` and `java.awt.Component.getPeer()` methods have been removed.  
+                            The `java.awt.peer` and `java.awt.dnd.peer` are no longer accessible and are considered
+                            internal implementation details, the API may be removed without notice or changed in non
+                            compatible ways.  Methods exposing this API, such as `java.awt.Font.getPeer()`
+                            have been removed since JDK 9.  
+                            Since Font rendering is platform independent, there are no substitutes for this method.
+                        </message>              
+                    <link title="java.awt.peer Not Accessible" href="https://docs.oracle.com/en/java/javase/11/migrate/index.html#JSMIG-GUID-0C350BAB-F2C8-409E-AD3E-63831C684A55"/>
+                </hint>
+            </perform>
+        </rule>
+        <rule id="java-removals-00150">
             <when>
                 <javaclass references="java.lang.ClassLoader"/>
             </when>

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ComponentGetPeer.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ComponentGetPeer.java
@@ -12,7 +12,6 @@ public class ComponentGetPeer {
          {
             Component comp = c.getComponent(0);
             java.awt.ComponentPeer peer1 = comp.getPeer();
-            String peer1Name = comp.getPeer().toString();  
          }
    }
 }

--- a/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ComponentGetPeer.java
+++ b/rules-reviewed/openjdk11/openjdk8/tests/data/java-removals/ComponentGetPeer.java
@@ -1,0 +1,18 @@
+import java.awt.*;
+
+public class ComponentGetPeer {
+    
+    public static void main(String[] args) {
+        java.awt.peer.FontPeer peer = new java.awt.Font("Sans", 1, 1).getPeer();
+        String peerName = peer.toString();
+        java.awt.Container cont = new java.awt.Container();
+        Container c = new Container();
+        int count = c.getComponentCount();
+        if (count != 0) 
+         {
+            Component comp = c.getComponent(0);
+            java.awt.ComponentPeer peer1 = comp.getPeer();
+            String peer1Name = comp.getPeer().toString();  
+         }
+   }
+}

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -104,7 +104,7 @@
                     <fail message="[java-removals-00050-test] Hint not found"/>
                 </perform>
             </rule>
-            <rule id="java-removals-00101-test">
+            <rule id="java-removals-00120-test-1">
                 <when>
                     <not>
                         <iterable-filter size="3">
@@ -116,7 +116,7 @@
                     <fail message="[java-removals] sun.misc.BASE64Encoder hints not found"/>
                 </perform>
             </rule>
-            <rule id="java-removals-00120-test-1">
+            <rule id="java-removals-00120-test-2">
                 <when>
                     <not>
                         <iterable-filter size="3">
@@ -139,8 +139,20 @@
                 <perform>
                     <fail message="[java-removals-00130-test] Could not find hint"/>
                 </perform>
-            </rule>                 
+            </rule>
             <rule id="java-removals-00140-test">
+                <when>
+                    <not>
+                        <!-- <iterable-filter size="1"> -->
+                        <hint-exists message="The `java.awt.Font.getPeer\(\)` and `java.awt.Component.getPeer\(\)` methods*" />
+                        <!-- </iterable-filter> -->
+                    </not>
+                </when>
+                <perform>
+                    <fail message="[java-removals-00140-test] The `java.awt.Font.getPeer()` method has been removed hint was not found."/>
+                </perform>
+            </rule>
+            <rule id="java-removals-00150-test">
                 <when>
                     <not>
                         <iterable-filter size="2">
@@ -149,7 +161,7 @@
                     </not>
                 </when>
                 <perform>
-                    <fail message="[java-removals] java-removals-00140 failed"/>
+                    <fail message="[java-removals] java-removals-00150 failed"/>
                 </perform>
             </rule>
         </rules>

--- a/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
+++ b/rules-reviewed/openjdk11/openjdk8/tests/java-removals.windup.test.xml
@@ -143,9 +143,9 @@
             <rule id="java-removals-00140-test">
                 <when>
                     <not>
-                        <!-- <iterable-filter size="1"> -->
-                        <hint-exists message="The `java.awt.Font.getPeer\(\)` and `java.awt.Component.getPeer\(\)` methods*" />
-                        <!-- </iterable-filter> -->
+                      <iterable-filter size="2">
+                         <hint-exists message="The `java.awt.Font.getPeer\(\)` and `java.awt.Component.getPeer\(\)` methods*" /> 
+                      </iterable-filter> 
                     </not>
                 </when>
                 <perform>


### PR DESCRIPTION
@jmle Can I ask you to investigate an issue for me?
The Componet.getPeer() aspect of this rule is not firing even though I have rebuild the CLI after the PR to add the Component.class to the removed classes jar.
If I run a custom rule from the 5.3.0 CLI  containing exactly the same logic. It does fire.
