### PR TITLE
Add DLL rule

### DIFF
--- a/rules-reviewed/os/windows/os-specific.windup.xml
+++ b/rules-reviewed/os/windows/os-specific.windup.xml
@@ -30,5 +30,16 @@
                 <matches pattern="[A-z]:([\\][^\n\t]+)+|(\\\\([^\\\,\n\t]+)\\\S+)+" />
             </where>
         </rule>
+        <rule id="os-specific-00002">
+            <when>
+                <file filename="{*}.dll"/>
+            </when>
+            <perform>
+                <hint title="Dynamic-Link Library (DLL)" effort="3" category-id="mandatory">
+                    <message>This Dynamic-Link Library is Microsoft Windows platform dependent. It needs to be replaced with a Linux-style shared library.</message>
+                    <tag>ms-windows</tag>
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules-reviewed/os/windows/os-specific.windup.xml
+++ b/rules-reviewed/os/windows/os-specific.windup.xml
@@ -35,7 +35,7 @@
                 <file filename="{*}.dll"/>
             </when>
             <perform>
-                <hint title="Dynamic-Link Library (DLL)" effort="3" category-id="mandatory">
+                <hint title="Dynamic-Link Library (DLL)" effort="5" category-id="mandatory">
                     <message>This Dynamic-Link Library is Microsoft Windows platform dependent. It needs to be replaced with a Linux-style shared library.</message>
                     <tag>ms-windows</tag>
                 </hint>

--- a/rules-reviewed/os/windows/tests/os-specific.windup.test.xml
+++ b/rules-reviewed/os/windows/tests/os-specific.windup.test.xml
@@ -17,6 +17,18 @@
                     <fail message="Windows platform dependent hint was not found!" />
                 </perform>
             </rule>
+            <rule id="os-specific-test-00002">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="This Dynamic-Link Library is Microsoft Windows platform dependent.*" />
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Dynamic-Link Library hint was not found!" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
Some Java projects can embed DLL files for native Windows calls.

This rule checks if there are *.dll files in the project