### PR TITLE
WINDUP-3295: add dependency migration to javax-jakarta recipe

### DIFF
--- a/rules-reviewed/openrewrite/jakarta/javax/imports/rewrite.yml
+++ b/rules-reviewed/openrewrite/jakarta/javax/imports/rewrite.yml
@@ -26,32 +26,55 @@ recipeList:
   - org.jboss.windup.JavaxWebsocketToJakartaWebsocket
   - org.jboss.windup.JavaxWsToJakartaWs
   - org.jboss.windup.JavaxXmlBindToJakartaXmlBind
-  - org.jboss.windup.JavaxXmlCryptoToJakartaXmlCrypto
-  - org.jboss.windup.JavaxXmlDatatypeToJakartaXmlDatatype
-  - org.jboss.windup.JavaxXmlNamespaceToJakartaXmlNamespace
-  - org.jboss.windup.JavaxXmlParsersToJakartaXmlParsers
   - org.jboss.windup.JavaxXmlSoapToJakartaXmlSoap
-  - org.jboss.windup.JavaxXmlStreamToJakartaXmlStream
-  - org.jboss.windup.JavaxXmlTransformToJakartaXmlTransform
-  - org.jboss.windup.JavaxXmlValidationToJakartaXmlValidation
   - org.jboss.windup.JavaxXmlWsToJakartaXmlWs
-  - org.jboss.windup.JavaxXmlXPathToJakartaXmlXPath
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxActivationToJakartaActivation
 displayName: javax.activation to jakarta.activation
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.activation
+      artifactId: jakarta.activation-api
+      version: 2.x
+      onlyIfUsing: javax.activation.*
 
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.activation
+      artifactId: jakarta.activation-api
+      newVersion: 2.x
+
+  # Note: ChangePackage does not update java doc references.
+  # f(x).transaction
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.activation
       newPackageName: jakarta.activation
+      recursive: true
+
+  # Remove Javax Batch API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.activation
+      artifactId: javax.activation-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxAnnotationToJakartaAnnotation
 displayName: javax.annotation to jakarta.annotation
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      version: 2.x
+      onlyIfUsing: javax.annotation.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.annotation
+      artifactId: jakarta.annotation-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: javax.annotation.Generated
       newFullyQualifiedTypeName: jakarta.annotation.Generated
@@ -95,15 +118,39 @@ recipeList:
       oldFullyQualifiedTypeName: javax.annotation.sql.DataSourceDefinitions
       newFullyQualifiedTypeName: jakarta.annotation.sql.DataSourceDefinitions
 
+  # Remove Javax annotation API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.annotation
+      artifactId: javax.annotation-api
+
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxBatchToJakartaBatch
 displayName: javax.batch to jakarta.batch
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.batch
+      artifactId: jakarta.batch-api
+      version: 2.x
+      onlyIfUsing: javax.batch.*
 
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.batch
+      artifactId: jakarta.batch-api
+      newVersion: 2.x
+
+  # Note: ChangePackage does not update java doc references.
+  # f(x).batch
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.batch
       newPackageName: jakarta.batch
+      recursive: true
+
+  # Remove Javax Batch API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.batch
+      artifactId: javax.batch-api
 
 
 ---
@@ -111,10 +158,27 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxDecoratorToJakartaDecorator
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.enterprise
+      artifactId: jakarta.enterprise.cdi-api
+      version: 2.x
+      onlyIfUsing: javax.decorator.+
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.enterprise
+      artifactId: jakarta.enterprise.cdi-api
+      newVersion: 2.x
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.decorator
       newPackageName: jakarta.decorator
+      recursive: true
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.enterprise
+      artifactId: cdi-api
 
 
 ---
@@ -122,264 +186,612 @@ type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxEjbToJakartaEjb
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.ejb
+      artifactId: jakarta.ejb-api
+      version: 4.x
+      onlyIfUsing: javax.ejb.+
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.ejb
+      artifactId: jakarta.ejb-api
+      newVersion: 4.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.ejb
       newPackageName: jakarta.ejb
+      recursive: true
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.ejb
+      artifactId: javax.ejb-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxElToJakartaEl
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.el
+      artifactId: jakarta.el-api
+      version: 4.x
+      onlyIfUsing: javax.el.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.el
+      artifactId: jakarta.el-api
+      newVersion: 4.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.el
       newPackageName: jakarta.el
+      recursive: true
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.el
+      artifactId: javax.el-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxEnterpriseToJakartaEnterprise
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.enterprise
+      artifactId: jakarta.enterprise.cdi-api
+      version: 3.0.1
+      onlyIfUsing: javax.enterprise.+
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.enterprise
+      artifactId: jakarta.enterprise.cdi-api
+      newVersion: 3.0.1
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.enterprise
       newPackageName: jakarta.enterprise
+      recursive: true
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.enterprise
+      artifactId: cdi-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxFacesToJakartaFaces
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.faces
+      artifactId: jakarta.faces-api
+      version: 3.x
+      onlyIfUsing: javax.faces.+
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.faces
+      artifactId: jakarta.faces-api
+      newVersion: 3.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.faces
       newPackageName: jakarta.faces
+      recursive: true
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.faces
+      artifactId: javax.faces-api
+
+  # Remove Javax API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.glassfish
+      artifactId: javax.faces
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxInjectToJakartaInject
 displayName: javax.inject to jakarta.inject
-
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.inject
+      artifactId: jakarta.inject-api
+      version: 2.x
+      onlyIfUsing: javax.inject.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.inject
+      artifactId: jakarta.inject-api
+      newVersion: 2.x
+
+  # Note: ChangePackage does not update java doc references.
+  # f(x).batch
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.inject
       newPackageName: jakarta.inject
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.inject
+      artifactId: javax.inject-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxInterceptorToJakartaInterceptor
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.interceptor
+      artifactId: jakarta.interceptor-api
+      version: 2.x
+      onlyIfUsing: javax.interceptor.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.interceptor
+      artifactId: jakarta.interceptor-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.interceptor
       newPackageName: jakarta.interceptor
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.interceptor
+      artifactId: javax.interceptor-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxJmsToJakartaJms
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.jms
+      artifactId: jakarta.jms-api
+      version: 3.x
+      onlyIfUsing: javax.jms.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.jms
+      artifactId: jakarta.jms-api
+      newVersion: 3.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.jms
       newPackageName: jakarta.jms
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.jms
+      artifactId: javax.jms-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxJsonToJakartaJson
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.json
+      artifactId: jakarta.json-api
+      version: 2.x
+      onlyIfUsing: javax.json.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.json
+      artifactId: jakarta.json-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.json
       newPackageName: jakarta.json
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.json
+      artifactId: javax.json-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxJwsToJakartaJws
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.jws
+      artifactId: jakarta.jws-api
+      version: 3.x
+      onlyIfUsing: javax.jws.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.jws
+      artifactId: jakarta.jws-api
+      newVersion: 3.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.jws
       newPackageName: jakarta.jws
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.jws
+      artifactId: javax.jws-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxMailToJakartaMail
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.mail
+      artifactId: jakarta.mail-api
+      version: 2.x
+      onlyIfUsing: javax.mail.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.mail
+      artifactId: jakarta.mail-api
+      newVersion: 2.x
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.mail
       newPackageName: jakarta.mail
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.mail
+      artifactId: javax.mail-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxPersistenceToJakartaPersistence
 displayName: Change type example
 recipeList:
-   - org.openrewrite.java.ChangePackage:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.persistence
+      artifactId: jakarta.persistence-api
+      version: 3.x
+      onlyIfUsing: javax.persistence.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.persistence
+      artifactId: jakarta.persistence-api
+      newVersion: 3.x
+
+  - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.persistence
       newPackageName: jakarta.persistence
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.persistence
+      artifactId: javax.persistence-api
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: org.eclipse.persistence
+      artifactId: javax.persistence
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxResourceToJakartaResource
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.resource
+      artifactId: jakarta.resource-api
+      version: 2.x
+      onlyIfUsing: javax.resource.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.resource
+      artifactId: jakarta.resource-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.resource
       newPackageName: jakarta.resource
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.resource
+      artifactId: javax.resource-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxSecurityToJakartaSecurity
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.security.enterprise
+      artifactId: jakarta.security.enterprise-api
+      version: 2.x
+      onlyIfUsing: javax.security.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.security.enterprise
+      artifactId: jakarta.security.enterprise-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.security
       newPackageName: jakarta.security
+      recursive: true
+
+  # Remove Javax Inject API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.security.enterprise
+      artifactId: javax.security.enterprise-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxServletToJakartaServlet
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.servlet
+      artifactId: jakarta.servlet-api
+      version: 5.x
+      onlyIfUsing: javax.servlet.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.servlet
+      artifactId: jakarta.servlet-api
+      newVersion: 5.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.servlet
       newPackageName: jakarta.servlet
+      recursive: true
+
+  # Remove Javax Transaction API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.servlet
+      artifactId: javax.servlet-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxTransactionToJakartaTransaction
 displayName: javax.transaction to jakarta.transaction
-
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.transaction
+      artifactId: jakarta.transaction-api
+      version: 2.x
+      onlyIfUsing: javax.transaction.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.transaction
+      artifactId: jakarta.transaction-api
+      newVersion: 2.x
+
+  # f(x).transaction
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.transaction
       newPackageName: jakarta.transaction
+      recursive: true
+
+  # Remove Javax Transaction API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.transaction
+      artifactId: javax.transaction-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxValidationToJakartaValidation
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.validation
+      artifactId: jakarta.validation-api
+      version: 2.x
+      onlyIfUsing: javax.validation.*
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.validation
+      artifactId: jakarta.validation-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.validation
       newPackageName: jakarta.validation
+      recursive: true
+
+  # Remove Javax Validation API
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.validation
+      artifactId: validation-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxWebsocketToJakartaWebsocket
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-api
+      version: 2.x
+      onlyIfUsing: javax.websocket.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.websocket
+      artifactId: jakarta.websocket-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.websocket
       newPackageName: jakarta.websocket
+      recursive: true
+
+  # Remove Javax Transaction API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.websocket
+      artifactId: javax.websocket-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxWsToJakartaWs
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.ws.rs
+      artifactId: jakarta.ws.rs-api
+      version: 3.x
+      onlyIfUsing: javax.ws.+
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.ws.rs
+      artifactId: jakarta.ws.rs-api
+      newVersion: 3.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.ws
       newPackageName: jakarta.ws
+      recursive: true
+
+  # Remove Javax Transaction API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.ws.rs
+      artifactId: javax.ws.rs-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxXmlBindToJakartaXmlBind
 displayName: javax.xml.bind to jakarta.xml.bind
-
 recipeList:
+  # JaxB API(x) .. update
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
+      version: 3.x
+      onlyIfUsing: javax.xml.bind.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.xml.bind
+      artifactId: jakarta.xml.bind-api
+      newVersion: 3.x
+
+  # JaxB Runtime(x) .. update
+  - org.openrewrite.maven.AddDependency:
+      groupId: org.glassfish.jaxb
+      artifactId: jaxb-runtime
+      version: 3.x
+      scope: runtime
+      onlyIfUsing: javax.xml.bind.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: org.glassfish.jaxb
+      artifactId: jaxb-runtime
+      newVersion: 3.x
+
+  # f(x).xml.bind
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.xml.bind
       newPackageName: jakarta.xml.bind
+      recursive: true
 
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlCryptoToJakartaXmlCrypto
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.crypto
-      newPackageName: jakarta.xml.crypto
+  # Remove the legacy Javax JAXB API in favor of the the jakarta artifact.
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.xml.bind
+      artifactId: jaxb-api
 
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlDatatypeToJakartaXmlDatatype
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.datatype
-      newPackageName: jakarta.xml.datatype
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlNamespaceToJakartaXmlNamespace
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.namespace
-      newPackageName: jakarta.xml.namespace
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlParsersToJakartaXmlParsers
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.parsers
-      newPackageName: jakarta.xml.parsers
+  # Remove the legacy sun JAXB runtime in favor of the glassfish artifact.
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: com.sun.xml.bind
+      artifactId: jaxb-impl
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxXmlSoapToJakartaXmlSoap
 displayName: Change type example
 recipeList:
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.xml.soap
+      artifactId: jakarta.xml.soap-api
+      version: 2.x
+      onlyIfUsing: javax.xml.soap.*
+
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.xml.soap
+      artifactId: jakarta.xml.soap-api
+      newVersion: 2.x
+
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.xml.soap
       newPackageName: jakarta.xml.soap
+      recursive: true
 
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlStreamToJakartaXmlStream
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.stream
-      newPackageName: jakarta.xml.stream
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlTransformToJakartaXmlTransform
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.transform
-      newPackageName: jakarta.xml.transform
-
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlValidationToJakartaXmlValidation
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.validation
-      newPackageName: jakarta.xml.validation
+  # Remove Javax API
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.xml.soap
+      artifactId: javax.xml.soap-api
 
 ---
 type: specs.openrewrite.org/v1beta/recipe
 name: org.jboss.windup.JavaxXmlWsToJakartaXmlWs
 displayName: javax.xml.ws to jakarta.xml.ws
 recipeList:
+  # JaxWS API(x) .. update
+  - org.openrewrite.maven.AddDependency:
+      groupId: jakarta.xml.ws
+      artifactId: jakarta.xml.ws-api
+      version: 3.x
+      onlyIfUsing: javax.xml.ws.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: jakarta.xml.ws
+      artifactId: jakarta.xml.ws-api
+      newVersion: 3.x
+
+  # JaxWS Runtime(x) .. update
+  - org.openrewrite.maven.AddDependency:
+      groupId: com.sun.xml.ws
+      artifactId: jaxws-rt
+      version: 3.x
+      scope: runtime
+      onlyIfUsing: javax.xml.ws.*
+
+  # Upgrade the dependency to use the jakarta namespace if an older version already exists.
+  - org.openrewrite.maven.UpgradeDependencyVersion:
+      groupId: com.sun.xml.ws
+      artifactId: jaxws-rt
+      newVersion: 3.x
+
+  # f(x).xml.ws
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.xml.ws
       newPackageName: jakarta.xml.ws
+      recursive: true
 
----
-type: specs.openrewrite.org/v1beta/recipe
-name: org.jboss.windup.JavaxXmlXPathToJakartaXmlXPath
-displayName: Change type example
-recipeList:
-  - org.openrewrite.java.ChangePackage:
-      oldPackageName: javax.xml.xpath
-      newPackageName: jakarta.xml.xpath
-
+  # Remove Javax JaxWs API(x)
+  - org.openrewrite.maven.RemoveDependency:
+      groupId: javax.xml.ws
+      artifactId: jaxws-api

--- a/rules-reviewed/openrewrite/jakarta/javax/imports/rewrite.yml
+++ b/rules-reviewed/openrewrite/jakarta/javax/imports/rewrite.yml
@@ -132,7 +132,7 @@ recipeList:
       groupId: jakarta.batch
       artifactId: jakarta.batch-api
       version: 2.x
-      onlyIfUsing: javax.batch.*
+      onlyIfUsing: javax.batch.+
 
   # Upgrade the dependency to use the jakarta namespace if an older version already exists.
   - org.openrewrite.maven.UpgradeDependencyVersion:
@@ -607,13 +607,13 @@ recipeList:
   - org.openrewrite.maven.AddDependency:
       groupId: jakarta.validation
       artifactId: jakarta.validation-api
-      version: 2.x
-      onlyIfUsing: javax.validation.*
+      version: 3.0.1
+      onlyIfUsing: javax.validation.+
 
   - org.openrewrite.maven.UpgradeDependencyVersion:
       groupId: jakarta.validation
       artifactId: jakarta.validation-api
-      newVersion: 2.x
+      newVersion: 3.0.1
 
   - org.openrewrite.java.ChangePackage:
       oldPackageName: javax.validation


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3295

The openrewrite recipe contained in this PR requires https://github.com/windup/windup-distribution/pull/84 if it is to be used via the mta-cli 