### PR TITLE
Azure - Detect plain-text passwords in XML config files

### DIFF
--- a/rules-reviewed/azure/azure-password.windup.xml
+++ b/rules-reviewed/azure/azure-password.windup.xml
@@ -20,7 +20,11 @@
     <rules>
         <rule id="azure-password-01000">
             <when>
-                <filecontent filename="application{*}.{extensions}" pattern="{password}"/>
+                <or>
+                    <filecontent filename="application{*}.{extensions}" pattern="{password}"/>
+                    <xmlfile matches="//password" /><!-- any 'Password' element -->
+                    <xmlfile matches="//*[@name='Password']" /><!-- Any element with a 'Password' property -->
+                </or>
             </when>
             <perform>
                 <hint title="Password found in configuration file" category-id="potential" effort="3">

--- a/rules-reviewed/azure/tests/azure-password.windup.test.xml
+++ b/rules-reviewed/azure/tests/azure-password.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="azure-password-test-01000">
                 <when>
                     <not>
-                        <iterable-filter size="3">
+                        <iterable-filter size="7">
                             <hint-exists message="Password found in configuration file." />
                         </iterable-filter>
                     </not>

--- a/rules-reviewed/azure/tests/data/azure-password/h2-ds.xml
+++ b/rules-reviewed/azure/tests/data/azure-password/h2-ds.xml
@@ -1,0 +1,21 @@
+<datasources>
+    <datasource jndi-name="java:jboss/datasources/DeployedDS" enabled="true" use-java-context="true"
+                pool-name="H2DS">
+        <connection-url>jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</connection-url>
+        <driver>h2</driver>
+        <pool></pool>
+        <security>
+            <user-name>sa</user-name>
+            <password>sa</password>
+        </security>
+    </datasource>
+    <xa-datasource jndi-name="java:/H2XADS" pool-name="H2XADS">
+        <xa-datasource-class>org.h2.jdbcx.JdbcDataSource</xa-datasource-class>
+        <xa-datasource-property name="URL">jdbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE</xa-datasource-property>
+        <driver>h2</driver>
+        <security>
+            <user-name>sa</user-name>
+            <password>sa</password>
+        </security>
+    </xa-datasource>
+</datasources>

--- a/rules-reviewed/azure/tests/data/azure-password/ora-ds.xml
+++ b/rules-reviewed/azure/tests/data/azure-password/ora-ds.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datasources>
+  <xa-datasource>
+    <jndi-name>example_ds</jndi-name>
+    <track-connection-by-tx>false</track-connection-by-tx>
+    <isSameRM-override-value>false</isSameRM-override-value>
+    <min-pool-size>5</min-pool-size>
+    <max-pool-size>100</max-pool-size>
+    <blocking-timeout-millis>5000</blocking-timeout-millis>
+    <idle-timeout-minutes>15</idle-timeout-minutes>
+    <transaction-isolation>TRANSACTION_READ_COMMITTED</transaction-isolation>
+    <xa-datasource-class>oracle.jdbc.xa.client.OracleXADataSource</xa-datasource-class>
+    <xa-datasource-property name="URL">jdbc:oracle:thin:@otto.na.ad.atg.com:1521:ora10r2</xa-datasource-property>
+    <xa-datasource-property name="User">username</xa-datasource-property>
+    <xa-datasource-property name="Password">password</xa-datasource-property>
+    <exception-sorter-class-name>
+        org.jboss.resource.adapter.jdbc.vendor.OracleExceptionSorter
+    </exception-sorter-class-name>
+  </xa-datasource>
+</datasources>

--- a/rules-reviewed/azure/tests/data/azure-password/pgsql-ds.xml
+++ b/rules-reviewed/azure/tests/data/azure-password/pgsql-ds.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<datasources>
+    <datasource jndi-name="java:jboss/datasources/MyApplication" pool-name="MyApplication"
+        enabled="true" use-java-context="true">
+        <connection-url>jdbc:postgresql://localhost:5432/myapplication</connection-url>
+        <driver>postgresql-9.4.1208.jar</driver>
+        <security>
+            <user-name>postgres</user-name>
+            <password>1234</password>
+        </security>
+    </datasource>
+</datasources>


### PR DESCRIPTION
Extend the detection of plain-text passwords from #705 to XML configuration files