### PR TITLE
WINDUP-3227: tags must be in metadata section

### DIFF
--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -25,7 +25,7 @@ jobs:
         run: mvn -B clean install -DskipTests
 
   windup-rulesets-build:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     needs: [windup-build]
     steps:
       - uses: actions/checkout@v2.3.4

--- a/rules-reviewed/azure/azure-file-system.windup.xml
+++ b/rules-reviewed/azure/azure-file-system.windup.xml
@@ -15,7 +15,7 @@
         <sourceTechnology id="springboot"/>
         <targetTechnology id="azure-appservice"/>
         <targetTechnology id="azure-aks"/>
-        <tag>file system</tag>
+        <tag>file-system</tag>
     </metadata>
     <rules>
         <rule id="azure-file-system-01000">

--- a/rules-reviewed/azure/eap/eap-to-azure-appservice-environment-variables.windup.xml
+++ b/rules-reviewed/azure/eap/eap-to-azure-appservice-environment-variables.windup.xml
@@ -13,7 +13,7 @@
         </dependencies>
         <sourceTechnology id="eap" versionRange="[7,8)" />
         <targetTechnology id="azure-appservice"/>
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>Azure</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/azure/springboot/spring-boot-to-azure-cache.windup.xml
+++ b/rules-reviewed/azure/springboot/spring-boot-to-azure-cache.windup.xml
@@ -14,6 +14,7 @@
         <targetTechnology id="azure-appservice"/>
         <targetTechnology id="azure-aks"/>
         <tag>cache</tag>
+        <tag>redis</tag>
     </metadata>
     <rules>
         <rule id="spring-boot-to-azure-cache-redis-01000">

--- a/rules-reviewed/azure/springboot/spring-boot-to-azure-jms-broker.windup.xml
+++ b/rules-reviewed/azure/springboot/spring-boot-to-azure-jms-broker.windup.xml
@@ -14,6 +14,7 @@
         <targetTechnology id="azure-appservice"/>
         <targetTechnology id="azure-aks"/>
         <tag>broker</tag>
+        <tag>activemq</tag>
     </metadata>
     <rules>
         <rule id="spring-boot-to-azure-jms-broker-01000">

--- a/rules-reviewed/azure/springboot/spring-boot-to-azure-schedule-job.windup.xml
+++ b/rules-reviewed/azure/springboot/spring-boot-to-azure-schedule-job.windup.xml
@@ -14,6 +14,7 @@
         <targetTechnology id="azure-appservice"/>
         <targetTechnology id="azure-aks"/>
         <tag>scheduler</tag>
+        <tag>quartz</tag>
     </metadata>
     <rules>
         <rule id="spring-boot-to-azure-schedule-job-01000">

--- a/rules-reviewed/azure/springboot/spring-boot-to-azure-static-content.windup.xml
+++ b/rules-reviewed/azure/springboot/spring-boot-to-azure-static-content.windup.xml
@@ -13,7 +13,7 @@
         <sourceTechnology id="springboot"/>
         <targetTechnology id="azure-appservice"/>
         <targetTechnology id="azure-aks"/>
-        <tag>static content</tag>
+        <tag>static-content</tag>
     </metadata>
     <rules>
         <rule id="spring-boot-to-azure-static-content-01000">

--- a/rules-reviewed/eap6/commonj/commonj.windup.xml
+++ b/rules-reviewed/eap6/commonj/commonj.windup.xml
@@ -14,6 +14,7 @@
         <sourceTechnology id="websphere"/>
         <targetTechnology id="eap" versionRange="[6,)"/>
         <targetTechnology id="java-ee" versionRange="[6,)"/>
+        <tag>commonj</tag>
     </metadata>
     <rules>
         <rule id="commonj-01000">

--- a/rules-reviewed/eap6/glassfish/xml-glassfish.windup.xml
+++ b/rules-reviewed/eap6/glassfish/xml-glassfish.windup.xml
@@ -15,6 +15,7 @@
         <targetTechnology id="eap" versionRange="[6,)" />
         <tag>web-app</tag>
         <tag>glassfish</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="xml-glassfish-01000">

--- a/rules-reviewed/eap6/java-ee/java-ee-jaxrpc.windup.xml
+++ b/rules-reviewed/eap6/java-ee/java-ee-jaxrpc.windup.xml
@@ -12,6 +12,8 @@
         </dependencies>
         <sourceTechnology id="java-ee" />
         <targetTechnology id="eap" versionRange="[6,)" />
+        <tag>jax-rpc</tag>
+        <tag>soap</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/java-ee/seam/seam-java.windup.xml
+++ b/rules-reviewed/eap6/java-ee/seam/seam-java.windup.xml
@@ -15,6 +15,7 @@
         <sourceTechnology id="eap" versionRange="[4,6)"/>
         <sourceTechnology id="seam" versionRange="[2.0,2.1,2.2,2.3]"/>
         <targetTechnology id="eap" versionRange="[6,8)"/>
+        <tag>seam</tag>
     </metadata>
     <rules>
         <rule id="seam-java-00000">

--- a/rules-reviewed/eap6/java-ee/seam/seam-ui.windup.xml
+++ b/rules-reviewed/eap6/java-ee/seam/seam-ui.windup.xml
@@ -14,6 +14,8 @@
         <sourceTechnology id="eap" versionRange="[5,6)"/>
         <sourceTechnology id="seam" versionRange="[2.0,2.1,2.2,2.3]"/>
         <targetTechnology id="eap" versionRange="[6,8)" />
+        <tag>seam</tag>
+        <tag>jsf</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/java-ee/xml-webservices.windup.xml
+++ b/rules-reviewed/eap6/java-ee/xml-webservices.windup.xml
@@ -12,6 +12,7 @@
         </dependencies>
         <sourceTechnology id="java-ee" />
         <targetTechnology id="eap" versionRange="[6,)" />
+        <tag>webservice</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/jboss-eap5/resteasy.windup.xml
+++ b/rules-reviewed/eap6/jboss-eap5/resteasy.windup.xml
@@ -10,6 +10,7 @@
         </dependencies>
         <sourceTechnology id="eap" versionRange="[5,6)" />
         <targetTechnology id="eap" versionRange="[6,7)" />
+        <tag>resteasy</tag>
     </metadata>
     <rules>
         <rule id="resteasy-eap5-000001">

--- a/rules-reviewed/eap6/jonas/xml-jonas.windup.xml
+++ b/rules-reviewed/eap6/jonas/xml-jonas.windup.xml
@@ -14,6 +14,7 @@
         <targetTechnology id="eap" versionRange="[6,)" />
         <tag>jonas</tag>
         <tag>web-app</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="xml-jonas-01000">

--- a/rules-reviewed/eap6/jotm/jotm.rhamt.xml
+++ b/rules-reviewed/eap6/jotm/jotm.rhamt.xml
@@ -10,6 +10,8 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="eap" versionRange="[6,)" />
+        <tag>transactions</tag>
+        <tag>jta</tag>
     </metadata>
     <rules>
         <rule id="jotm-00001">

--- a/rules-reviewed/eap6/jrun/xml-jrun.windup.xml
+++ b/rules-reviewed/eap6/jrun/xml-jrun.windup.xml
@@ -14,6 +14,7 @@
         <targetTechnology id="eap" versionRange="[6,)" />
         <tag>web-app</tag>
         <tag>jrun</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="xml-jrun-01000">

--- a/rules-reviewed/eap6/orion/xml-orion.windup.xml
+++ b/rules-reviewed/eap6/orion/xml-orion.windup.xml
@@ -15,6 +15,7 @@
         <targetTechnology id="eap" versionRange="[6,)" />
         <tag>web-app</tag>
         <tag>orion</tag>
+         <tag>configuration</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/resin/xml-resin.windup.xml
+++ b/rules-reviewed/eap6/resin/xml-resin.windup.xml
@@ -15,6 +15,7 @@
         <targetTechnology id="eap" versionRange="[6,)"/>
         <tag>web-app</tag>
         <tag>resin</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="xml-resin-01000">

--- a/rules-reviewed/eap6/weblogic/weblogic-ejb.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-ejb.windup.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="weblogic" />
         <targetTechnology id="eap" versionRange="[6,)" />
+        <tag>ejb</tag>
+        <tag>weblogic</tag>
     </metadata>
     <rules>
         <rule id="weblogic-ejb-01000">

--- a/rules-reviewed/eap6/weblogic/weblogic-jms.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-jms.windup.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="weblogic" />
         <targetTechnology id="eap" versionRange="[6,7)" />
+        <tag>jms</tag>
+        <tag>weblogic</tag>
     </metadata>
     <rules>
         <rule id="weblogic-jms-00000">

--- a/rules-reviewed/eap6/weblogic/weblogic-services.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-services.windup.xml
@@ -14,6 +14,7 @@
         </dependencies>
         <sourceTechnology id="weblogic"/>
         <targetTechnology id="eap" versionRange="[6,7)"/>
+        <tag>weblogic</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/weblogic/weblogic-webapp.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-webapp.windup.xml
@@ -16,6 +16,7 @@
         <sourceTechnology id="weblogic" />
         <targetTechnology id="eap" versionRange="[6,7)" />
         <tag>web-app</tag>
+        <tag>weblogic</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/weblogic/weblogic-webservices.windup.xml
+++ b/rules-reviewed/eap6/weblogic/weblogic-webservices.windup.xml
@@ -14,6 +14,7 @@
         <sourceTechnology id="weblogic"/>
         <targetTechnology id="eap" versionRange="[6,7)"/>
         <tag>webservice</tag>
+        <tag>weblogic</tag>
     </metadata>
     <rules>
         <rule id="weblogic-webservices-01000">

--- a/rules-reviewed/eap6/websphere/websphere-jms.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-jms.windup.xml
@@ -13,6 +13,8 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="java-ee" versionRange="[6,)" />
+        <tag>jms</tag>
+        <tag>websphere</tag>
     </metadata>
     <rules>
         <rule id="websphere-jms-00000">

--- a/rules-reviewed/eap6/websphere/websphere-mq.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-mq.windup.xml
@@ -14,6 +14,8 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="java-ee" versionRange="[6,)" />
+        <tag>jms</tag>
+        <tag>websphere</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/websphere/websphere-mqe.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-mqe.windup.xml
@@ -14,6 +14,8 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="java-ee" versionRange="[6,)" />
+        <tag>jms</tag>
+        <tag>websphere</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap6/websphere/websphere-other.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-other.windup.xml
@@ -13,6 +13,7 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="java-ee" versionRange="[6,)" />
+        <tag>websphere</tag>
     </metadata>
 
 

--- a/rules-reviewed/eap6/websphere/websphere-xml.windup.xml
+++ b/rules-reviewed/eap6/websphere/websphere-xml.windup.xml
@@ -10,6 +10,7 @@
         </dependencies>
         <sourceTechnology id="websphere"/>
         <targetTechnology id="eap" versionRange="[6,7)"/>
+        <tag>websphere</tag>
     </metadata>
     <rules>
         <rule id="websphere-xml-01000">

--- a/rules-reviewed/eap7/eap5/base64.windup.xml
+++ b/rules-reviewed/eap7/eap5/base64.windup.xml
@@ -13,6 +13,8 @@
         <sourceTechnology id="java-ee" />
         <sourceTechnology id="eap"/>
         <targetTechnology id="eap" versionRange="[6,)" />
+        <tag>eap7</tag>
+        <tag>base64</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/eap5/jaxrpc.windup.xml
+++ b/rules-reviewed/eap7/eap5/jaxrpc.windup.xml
@@ -12,6 +12,8 @@
         </dependencies>
         <sourceTechnology id="java-ee" />
         <targetTechnology id="eap" versionRange="[7,)" />
+        <tag>jax-rpc</tag>
+        <tag>soap</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/eap5and6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap5and6/resteasy.windup.xml
@@ -12,6 +12,7 @@
         <sourceTechnology id="resteasy" versionRange="[2,3)" />
         <targetTechnology id="eap" versionRange="[7,)" />
         <targetTechnology id="resteasy" versionRange="[3,)" />
+        <tag>resteasy</tag>
     </metadata>
     <rules>
         <rule id="resteasy-eap5and6to7-000018">

--- a/rules-reviewed/eap7/eap6/eap6-xml.windup.xml
+++ b/rules-reviewed/eap7/eap6/eap6-xml.windup.xml
@@ -13,6 +13,7 @@
         </dependencies>
         <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="eap" versionRange="[7,)" />
+        <tag>configuration</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/eap6/hibernate4-xml.windup.xml
+++ b/rules-reviewed/eap7/eap6/hibernate4-xml.windup.xml
@@ -14,6 +14,8 @@
         <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="hibernate" versionRange="[5,)" />
         <targetTechnology id="eap" versionRange="[7,)" />
+        <tag>hibernate</tag>
+        <tag>configuration</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/eap6/hibernate4.windup.xml
+++ b/rules-reviewed/eap7/eap6/hibernate4.windup.xml
@@ -13,6 +13,8 @@
         <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="hibernate" versionRange="[5,)" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>hibernate</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="hibernate4-00001">

--- a/rules-reviewed/eap7/eap6/hsearch.windup.xml
+++ b/rules-reviewed/eap7/eap6/hsearch.windup.xml
@@ -13,6 +13,8 @@
         <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="hibernate-search" versionRange="[5,)" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>hibernate-search</tag>
+        <tag>hibernate</tag>
     </metadata>
     <rules>
         <rule id="hsearch-00000">

--- a/rules-reviewed/eap7/eap6/jax-ws.windup.xml
+++ b/rules-reviewed/eap7/eap6/jax-ws.windup.xml
@@ -13,6 +13,7 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="eap" versionRange="[7,)" />
+        <tag>jax-ws</tag>
     </metadata>
     <rules>
         <rule id="jax-ws-00000">

--- a/rules-reviewed/eap7/eap6/resteasy.windup.xml
+++ b/rules-reviewed/eap7/eap6/resteasy.windup.xml
@@ -12,6 +12,7 @@
         <sourceTechnology id="resteasy" versionRange="[2,3)" />
         <targetTechnology id="resteasy" versionRange="[3,)" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>resteasy</tag>
     </metadata>
     <!-- All links need to be replaced with GA documentation as currently there are only 7.0-beta doc available -->
     <rules>

--- a/rules-reviewed/eap7/eap6/ws-security.windup.xml
+++ b/rules-reviewed/eap7/eap6/ws-security.windup.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="eap" versionRange="[6,7)" />
         <targetTechnology id="eap" versionRange="[7,)" />
+        <tag>ws-security</tag>
+        <tag>security</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/eap70/hibernate50-51.windup.xml
+++ b/rules-reviewed/eap7/eap70/hibernate50-51.windup.xml
@@ -15,6 +15,7 @@
         <sourceTechnology id="eap" versionRange="(,7.0]" />
         <targetTechnology id="hibernate" versionRange="[5.1,)" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>hibernate</tag>
     </metadata>
     <rules>
         <rule id="hibernate50-51-00000">

--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.groovy
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.groovy
@@ -5,6 +5,7 @@ import org.jboss.windup.reporting.category.IssueCategoryRegistry
 import org.jboss.windup.reporting.model.QuickfixType
 import org.jboss.windup.reporting.quickfix.Quickfix
 import org.jboss.windup.rules.apps.java.model.JavaClassModel
+import org.jboss.windup.config.metadata.RuleMetadataType
 import org.ocpsoft.rewrite.context.EvaluationContext;
 import org.ocpsoft.rewrite.param.ParameterStore;
 
@@ -120,6 +121,7 @@ ruleSet("hibernate51-53-groovy")
 .addSourceTechnology(new TechnologyReference("hibernate", "(,5.1]"))
 .addTargetTechnology(new TechnologyReference("hibernate", "[5.3,)"))
 .addTargetTechnology(new TechnologyReference("eap", "[7,8)"))
+.addTag("hibernate")
 .addRule()
     .when(
         JavaClass.references("{*}.$methodParam({*}org.hibernate.engine.spi.SessionImplementor{*})").at(TypeReferenceLocation.METHOD)

--- a/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
+++ b/rules-reviewed/eap7/eap71/hibernate51-53.windup.xml
@@ -14,6 +14,7 @@
         <sourceTechnology id="hibernate" versionRange="(,5.1]" />
         <targetTechnology id="hibernate" versionRange="[5.3,)" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>hibernate</tag>
     </metadata>
     <rules>
         <!--https://issues.jboss.org/browse/WINDUPRULE-376-->

--- a/rules-reviewed/eap7/eap71/picketlink25.windup.xml
+++ b/rules-reviewed/eap7/eap71/picketlink25.windup.xml
@@ -13,6 +13,7 @@
         </dependencies>
         <sourceTechnology id="eap" versionRange="(,7.1]" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>picketlink</tag>
     </metadata>
     <rules>
         <rule id="picketlink25-00000">

--- a/rules-reviewed/eap7/eap71/resteasy30-36.windup.xml
+++ b/rules-reviewed/eap7/eap71/resteasy30-36.windup.xml
@@ -13,6 +13,7 @@
         </dependencies>
         <targetTechnology id="eap" versionRange="[7,8)" />
         <targetTechnology id="resteasy" versionRange="[3,)" />
+        <tag>resteasy</tag>
     </metadata>
     <rules>
         <!--https://issues.jboss.org/browse/WINDUPRULE-370 -->

--- a/rules-reviewed/eap7/eap72/maven-artemis-jms-client.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/maven-artemis-jms-client.rhamt.xml
@@ -10,7 +10,8 @@
             <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
-        <targetTechnology id="eap" versionRange="[7,8)" />        
+        <targetTechnology id="eap" versionRange="[7,8)" />    
+        <tag>jms</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-404 -->

--- a/rules-reviewed/eap7/eap72/maven-javax-to-jakarta.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/maven-javax-to-jakarta.rhamt.xml
@@ -12,7 +12,8 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="eap" versionRange="[7,8)" />  
-        <targetTechnology id="jakarta-ee" versionRange="[8]" />      
+        <targetTechnology id="jakarta-ee" versionRange="[8]" />
+        <tag>JakartaEE</tag>
     </metadata>
     <rules>
         <!-- Originally developed under https://issues.jboss.org/browse/WINDUPRULE-396 -->

--- a/rules-reviewed/eap7/eap72/maven-jboss-rmi-api_1.0_spec.rhamt.xml
+++ b/rules-reviewed/eap7/eap72/maven-jboss-rmi-api_1.0_spec.rhamt.xml
@@ -10,7 +10,8 @@
             <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
-        <targetTechnology id="eap" versionRange="[7,8)" />        
+        <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>rmi</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-401 -->

--- a/rules-reviewed/eap7/eap73/microprofile_removed_from_eap.mta.xml
+++ b/rules-reviewed/eap7/eap73/microprofile_removed_from_eap.mta.xml
@@ -10,7 +10,8 @@
             <addon id="org.jboss.windup.rules,windup-rules-javaee,3.0.0.Final" />
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
-        <targetTechnology id="eap" versionRange="[7,8)" />  
+        <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>EclipseMicroProfile</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-757 -->

--- a/rules-reviewed/eap7/weblogic/weblogic-jms.windup.xml
+++ b/rules-reviewed/eap7/weblogic/weblogic-jms.windup.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="weblogic" />
         <targetTechnology id="eap" versionRange="[7,8)" />
+        <tag>jms</tag>
+        <tag>weblogic</tag>
     </metadata>
     <rules>
         <rule id="weblogic-jms-eap7-00000">

--- a/rules-reviewed/eap7/weblogic/weblogic-services.windup.xml
+++ b/rules-reviewed/eap7/weblogic/weblogic-services.windup.xml
@@ -14,6 +14,7 @@
         </dependencies>
         <sourceTechnology id="weblogic"/>
         <targetTechnology id="eap" versionRange="[7,8)"/>
+        <tag>weblogic</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/weblogic/weblogic-webapp.windup.xml
+++ b/rules-reviewed/eap7/weblogic/weblogic-webapp.windup.xml
@@ -16,6 +16,7 @@
         <sourceTechnology id="weblogic" />
         <targetTechnology id="eap" versionRange="[7,8)" />
         <tag>web-app</tag>
+        <tag>weblogic</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/weblogic/weblogic-webservices.windup.xml
+++ b/rules-reviewed/eap7/weblogic/weblogic-webservices.windup.xml
@@ -14,6 +14,7 @@
         <sourceTechnology id="weblogic"/>
         <targetTechnology id="eap" versionRange="[7,8)"/>
         <tag>webservice</tag>
+        <tag>weblogic</tag>
     </metadata>
     <rules>
         <rule id="weblogic-webservices-eap7-01000">

--- a/rules-reviewed/eap7/weblogic/weblogic-xml-descriptors.windup.xml
+++ b/rules-reviewed/eap7/weblogic/weblogic-xml-descriptors.windup.xml
@@ -15,6 +15,7 @@
         <targetTechnology id="eap" versionRange="[7,8)" />
         <tag>weblogic</tag>
         <tag>descriptor</tag>
+        <tag>configuration</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/websphere/websphere-jms.windup.xml
+++ b/rules-reviewed/eap7/websphere/websphere-jms.windup.xml
@@ -13,6 +13,8 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[7,)" />
         <targetTechnology id="java-ee" versionRange="[7,)" />
+        <tag>jms</tag>
+        <tag>websphere</tag>
     </metadata>
     <rules>
         <rule id="websphere-jms-eap7-00000">

--- a/rules-reviewed/eap7/websphere/websphere-mq.windup.xml
+++ b/rules-reviewed/eap7/websphere/websphere-mq.windup.xml
@@ -14,6 +14,9 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[7,)" />
         <targetTechnology id="java-ee" versionRange="[7,)" />
+        <tag>jms</tag>
+        <tag>messaging</tag>
+        <tag>websphere</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/websphere/websphere-mqe.windup.xml
+++ b/rules-reviewed/eap7/websphere/websphere-mqe.windup.xml
@@ -14,6 +14,9 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[7,8)" />
         <targetTechnology id="java-ee" versionRange="[7,)" />
+        <tag>jms</tag>
+        <tag>messaging</tag>
+        <tag>websphere</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/eap7/websphere/websphere-other.windup.xml
+++ b/rules-reviewed/eap7/websphere/websphere-other.windup.xml
@@ -13,6 +13,7 @@
         <sourceTechnology id="websphere" />
         <targetTechnology id="eap" versionRange="[7,)" />
         <targetTechnology id="java-ee" versionRange="[7,)" />
+        <tag>websphere</tag>
     </metadata>
 
 

--- a/rules-reviewed/eap7/websphere/websphere-xml.windup.xml
+++ b/rules-reviewed/eap7/websphere/websphere-xml.windup.xml
@@ -10,6 +10,8 @@
         </dependencies>
         <sourceTechnology id="websphere"/>
         <targetTechnology id="eap" versionRange="[7,8)"/>
+        <tag>websphere</tag>
+        <tag>configuration</tag>
     </metadata>
     <rules>
         <rule id="eap7-websphere-xml-01000">

--- a/rules-reviewed/eapxp/eapxp2/eapxp_bootable_jar_maven_plugin_configuration_changes.mta.xml
+++ b/rules-reviewed/eapxp/eapxp2/eapxp_bootable_jar_maven_plugin_configuration_changes.mta.xml
@@ -14,7 +14,7 @@
         </dependencies>
         <sourceTechnology id="eapxp" />
         <targetTechnology id="eapxp" versionRange="[3,)" />
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>EAPXP</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/eapxp/eapxp2/eapxp_bootable_jar_maven_plugin_configuration_changes.mta.xml
+++ b/rules-reviewed/eapxp/eapxp2/eapxp_bootable_jar_maven_plugin_configuration_changes.mta.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="eapxp" />
         <targetTechnology id="eapxp" versionRange="[3,)" />
+        <tag>JBoss EAP</tag>
+        <tag>EAPXP</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-759 -->

--- a/rules-reviewed/eapxp/thorntail/remove_thorntail_yaml_configuration_files.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/remove_thorntail_yaml_configuration_files.mta.xml
@@ -14,7 +14,7 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>Thorntail</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/eapxp/thorntail/remove_thorntail_yaml_configuration_files.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/remove_thorntail_yaml_configuration_files.mta.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
+        <tag>JBoss EAP</tag>
+        <tag>Thorntail</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-740 -->

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
@@ -14,7 +14,7 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>Thorntail</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_boms.mta.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
+        <tag>JBoss EAP</tag>
+        <tag>Thorntail</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-738 -->

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_fractions.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_fractions.mta.xml
@@ -13,7 +13,7 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>Thorntail</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_fractions.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_fractions.mta.xml
@@ -13,6 +13,8 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
+        <tag>JBoss EAP</tag>
+        <tag>Thorntail</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-741 -->

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_maven_plugin.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_maven_plugin.mta.xml
@@ -14,7 +14,7 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
-        <tag>JBoss EAP</tag>
+        <tag>JBossEAP</tag>
         <tag>Thorntail</tag>
     </metadata>
     <rules>

--- a/rules-reviewed/eapxp/thorntail/replace_thorntail_maven_plugin.mta.xml
+++ b/rules-reviewed/eapxp/thorntail/replace_thorntail_maven_plugin.mta.xml
@@ -14,6 +14,8 @@
         </dependencies>
         <sourceTechnology id="thorntail" />
         <targetTechnology id="eapxp" versionRange="[2,)" />
+        <tag>JBoss EAP</tag>
+        <tag>Thorntail</tag>
     </metadata>
     <rules>
         <!-- https://issues.jboss.org/browse/WINDUPRULE-739 -->

--- a/rules-reviewed/fuse-service-works/soa-p-5/soa-p-5.windup.xml
+++ b/rules-reviewed/fuse-service-works/soa-p-5/soa-p-5.windup.xml
@@ -13,6 +13,7 @@
         </dependencies>
         <sourceTechnology id="soa-p" versionRange="(,5]" />
         <targetTechnology id="fsw" versionRange="[6,)" />
+        <tag>jboss-esb</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/fuse/sonic-catchall.windup.xml
+++ b/rules-reviewed/fuse/sonic-catchall.windup.xml
@@ -14,6 +14,7 @@
       <sourceTechnology id="sonic" />
       <targetTechnology id="camel" versionRange="[2,)" />
       <targetTechnology id="fuse" versionRange="[6,)" />
+       <tag>sonic</tag>
    </metadata>
 
    <rules>

--- a/rules-reviewed/fuse/sonicesb/sonic-esb.windup.xml
+++ b/rules-reviewed/fuse/sonicesb/sonic-esb.windup.xml
@@ -11,6 +11,8 @@
         </dependencies>
         <sourceTechnology id="sonic" />
         <targetTechnology id="fuse" versionRange="[6,)" />
+        <tag>sonic-esb</tag>
+        <tag>camel</tag>
     </metadata>
     <rules>
         <rule id="sonic-esb-01000">

--- a/rules-reviewed/fuse/sonicesb/xml-sonic-esb.windup.xml
+++ b/rules-reviewed/fuse/sonicesb/xml-sonic-esb.windup.xml
@@ -12,6 +12,7 @@
         </dependencies>
         <sourceTechnology id="sonicesb" />
         <targetTechnology id="fuse" versionRange="[6,)" />
+        <tag>sonic-esb</tag>
     </metadata>
 
     <rules>

--- a/rules-reviewed/hibernate/hibernate.windup.xml
+++ b/rules-reviewed/hibernate/hibernate.windup.xml
@@ -13,6 +13,7 @@
       <sourceTechnology id="hibernate" versionRange="[,3.9)" />
       <targetTechnology id="hibernate" versionRange="[4,)" />
       <targetTechnology id="eap" versionRange="[6,7)" />
+       <tag>hibernate</tag>
    </metadata>
 
    <rules>

--- a/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
+++ b/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
@@ -11,6 +11,8 @@
         </dependencies>
         <sourceTechnology id="oraclejdk" versionRange="[7,)"/>
         <targetTechnology id="openjdk" versionRange="[7,)" />
+        <tag>oracle-jdk</tag>
+        <tag>jdk</tag>
     </metadata>
     <rules>
         <!-- remove / change this rule if OpenJFX is shipped with RHEL. -->

--- a/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
+++ b/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
@@ -73,7 +73,7 @@
                         OpenJDK does not support the resource management API for Java.
                     </message>
                     <link href="https://access.redhat.com/solutions/2489791" title="Knowledge base article OracleJDK vs. OpenJDK" />
-                    <tag>Oracle JDK resource management</tag>
+                    <tag>Oracle-JDK-resource-management</tag>
                 </hint>
             </perform>
         </rule>
@@ -88,7 +88,7 @@
                         OpenJDK uses LCMS. If you continued to use KCMS by using the property ``sun.java2d.cmm=sun.java2d.cmm.kcms.KcmsServiceProvider``, remove this property and ensure in your tests that your application still works as expected.
                     </message>
                     <link href="https://access.redhat.com/solutions/2489791" title="Knowledge base article OracleJDK vs. OpenJDK" />
-                    <tag>JDK color management</tag>
+                    <tag>JDK-color-management</tag>
                 </hint>
             </perform>
         </rule>
@@ -105,7 +105,7 @@
                        Ensure during your tests that the application behaves as expected.
                     </message>
                     <link href="https://access.redhat.com/solutions/2489791" title="Knowledge base article OracleJDK vs. OpenJDK" />
-                    <tag>2D library</tag>
+                    <tag>2DLibrary</tag>
                 </hint>
             </perform>
             <where param="package">

--- a/rules-reviewed/openshift/java-rmi.windup.xml
+++ b/rules-reviewed/openshift/java-rmi.windup.xml
@@ -12,6 +12,8 @@
         <sourceTechnology id="java" />
         <sourceTechnology id="rmi" />
         <targetTechnology id="cloud-readiness" />
+        <tag>cloud</tag>
+        <tag>rmi</tag>
     </metadata>
     <rules>
         <rule id="java-rmi-00000">

--- a/rules-reviewed/openshift/local-storage.windup.xml
+++ b/rules-reviewed/openshift/local-storage.windup.xml
@@ -10,6 +10,7 @@
             <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
         </dependencies>
         <targetTechnology id="cloud-readiness" />
+        <tag>storage</tag>
     </metadata>
      <!--
        This rules could be merged together but they need to be separated due to issue WINDUP-1324 [https://issues.jboss.org/projects/WINDUP/issues/WINDUP-1324]

--- a/rules-reviewed/os/windows/os-specific.windup.xml
+++ b/rules-reviewed/os/windows/os-specific.windup.xml
@@ -11,6 +11,7 @@
         </dependencies>
         <!-- version ranges applied to from and to technologies -->
         <targetTechnology id="linux" />
+        <tag>ms-windows</tag>
     </metadata>
     <rules>
         <rule id="os-specific-00001">

--- a/rules-reviewed/quarkus/springboot/springboot-generic-catchall.windup.xml
+++ b/rules-reviewed/quarkus/springboot/springboot-generic-catchall.windup.xml
@@ -14,6 +14,7 @@
         <sourceTechnology id="springboot" />
         <targetTechnology id="quarkus" />
         <phase>PostMigrationRulesPhase</phase>
+        <tag>springboot</tag>
     </metadata>
     <rules>
         <rule id="springboot-generic-catchall-00100">


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUP-3227

Generally I've moved tags which are common to rules (and thus are meant  to apply to all rules in the ruleset) into the metadata section.

https://github.com/windup/windup/pull/1511 is needed for --includeTags to work as you'd expect (restrict rules that are run and show up in the report to those with the tags specified by this parameter) on the metadata tags