### PR TITLE
Detects Java SE Threads usage

### DIFF
--- a/rules/rules-reviewed/technology-usage/javase-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/javase-technology-usage.windup.xml
@@ -15,7 +15,7 @@
         <rule id="javase-technology-usage-01000">
             <when>
                 <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">Threads</property>
+                    <property name="name">Java Threads</property>
                 </graph-query>
             </when>
             <perform>

--- a/rules/rules-reviewed/technology-usage/javase-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/javase-technology-usage.windup.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0"?>
+<ruleset id="technology-usage-javase" xmlns="http://windup.jboss.org/schema/jboss-ruleset" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides statistical summaries of the Java SE APIs.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final" />
+        </dependencies>
+        <phase>PostMigrationRulesPhase</phase>
+    </metadata>
+    <rules>
+        <!-- Threads -->
+        <rule id="javase-technology-usage-01000">
+            <when>
+                <graph-query discriminator="TechnologyTagModel">
+                    <property name="name">Threads</property>
+                </graph-query>
+            </when>
+            <perform>
+                <technology-identified name="Java Threads">
+                    <tag name="Execute"/>
+                    <tag name="Processing"/>
+                    <tag name="Java EE"/>
+                </technology-identified>
+            </perform>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules/rules-reviewed/technology-usage/javase.windup.xml
+++ b/rules/rules-reviewed/technology-usage/javase.windup.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<ruleset
+    xmlns="http://windup.jboss.org/schema/jboss-ruleset" id="javase"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://windup.jboss.org/schema/jboss-ruleset http://windup.jboss.org/schema/jboss-ruleset/windup-jboss-ruleset.xsd">
+    <metadata>
+        <description>
+            This ruleset provides analysis of the Core Java SE APIs.
+        </description>
+        <dependencies>
+            <addon id="org.jboss.windup.rules,windup-rules-java,3.0.0.Final"/>
+        </dependencies>
+    </metadata>
+    <rules>
+        <rule id="javase-01000">
+            <when>
+                <javaclass references="java.lang.{classes}"/>
+            </when>
+            <perform>
+                <classification title="Threads" category-id="information" effort="0">
+                    <description>The application uses Thread APIs.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">Threads</technology-tag>
+            </perform>
+            <where param="classes">
+                <matches pattern="(Thread|ThreadDeath|ThreadGroup|ThreadLocal)"/>
+            </where>
+        </rule>
+    </rules>
+</ruleset>

--- a/rules/rules-reviewed/technology-usage/javase.windup.xml
+++ b/rules/rules-reviewed/technology-usage/javase.windup.xml
@@ -11,6 +11,7 @@
         </dependencies>
     </metadata>
     <rules>
+        <!-- Threads -->
         <rule id="javase-01000">
             <when>
                 <javaclass references="java.lang.{classes}"/>
@@ -19,10 +20,24 @@
                 <classification title="Threads" category-id="information" effort="0">
                     <description>The application uses Thread APIs.</description>
                 </classification>
-                <technology-tag level="INFORMATIONAL">Threads</technology-tag>
+                <technology-tag level="INFORMATIONAL">Java Threads</technology-tag>
             </perform>
             <where param="classes">
-                <matches pattern="(Thread|ThreadDeath|ThreadGroup|ThreadLocal)"/>
+                <matches pattern="(Thread|ThreadDeath|ThreadGroup|ThreadLocal|Runnable)"/>
+            </where>
+        </rule>
+        <rule id="javase-01100">
+            <when>
+                <javaclass references="java.util.concurrent.{classes}"/>
+            </when>
+            <perform>
+                <classification title="Threads" category-id="information" effort="0">
+                    <description>The application uses Concurrent Executors APIs.</description>
+                </classification>
+                <technology-tag level="INFORMATIONAL">Java Threads</technology-tag>
+            </perform>
+            <where param="classes">
+                <matches pattern="(ExecutorService|Executors|Executor|ScheduledExecutorService)"/>
             </where>
         </rule>
     </rules>

--- a/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEExecutor.java
+++ b/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEExecutor.java
@@ -1,0 +1,9 @@
+package com.jboss.windup.test;
+
+import java.util.concurrent.Executor;
+
+public class Main implements Executor {
+    public void execute(Runnable r) {
+        r.run();
+    }
+}

--- a/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEThread.java
+++ b/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEThread.java
@@ -1,7 +1,5 @@
 package com.jboss.windup.test;
 
-import java.lang.Thread;
-
 public class Main extends Thread {
 
     public static void main(String[] args) {

--- a/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEThread.java
+++ b/rules/rules-reviewed/technology-usage/tests/data/javase/JavaSEThread.java
@@ -1,0 +1,17 @@
+package com.jboss.windup.test;
+
+import java.lang.Thread;
+
+public class Main extends Thread {
+
+    public static void main(String[] args) {
+
+        Main thread = new Main();
+        thread.start();
+        System.out.println("The thread inside the main method!!!");
+    }
+
+    public void run() {
+        System.out.println("The thread outside the main method!!");
+    }
+}

--- a/rules/rules-reviewed/technology-usage/tests/javase-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/javase-technology-usage.windup.test.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<ruletest id="technology-usage-javase-test" xmlns="http://windup.jboss.org/schema/jboss-ruleset">
+    <testDataPath>data/javase/</testDataPath>
+    <rulePath>../javase.windup.xml</rulePath>
+    <rulePath>../javase-technology-usage.windup.xml</rulePath>
+    <ruleset>
+        <rules>
+            <rule id="javase-technology-usage-01000-test">
+                <when>
+                    <not>
+                        <technology-statistics-exists name="Threads" number-found="1">
+                            <tag name="Execute"/>
+                            <tag name="Processing"/>
+                            <tag name="Java EE"/>
+                        </technology-statistics-exists>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="Java SE Threads Technology Not Found" />
+                </perform>
+            </rule>
+        </rules>
+    </ruleset>
+</ruletest>

--- a/rules/rules-reviewed/technology-usage/tests/javase-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/javase-technology-usage.windup.test.xml
@@ -8,7 +8,7 @@
             <rule id="javase-technology-usage-01000-test">
                 <when>
                     <not>
-                        <technology-statistics-exists name="Threads" number-found="1">
+                        <technology-statistics-exists name="Java Threads" number-found="1">
                             <tag name="Execute"/>
                             <tag name="Processing"/>
                             <tag name="Java EE"/>
@@ -16,7 +16,7 @@
                     </not>
                 </when>
                 <perform>
-                    <fail message="Java SE Threads Technology Not Found" />
+                    <fail message="Java Threads Not Found" />
                 </perform>
             </rule>
         </rules>


### PR DESCRIPTION
This rule detects that an application is using Java SE Thread APIs. This is important to detect when running in an application server or the cloud