### PR TITLE
WINDUPRULE-932 Fix broken EAP Logging links in Weblogic to EAP Rules

### DIFF
--- a/rules/rules-reviewed/eap6/weblogic/weblogic.windup.xml
+++ b/rules/rules-reviewed/eap6/weblogic/weblogic.windup.xml
@@ -234,7 +234,7 @@
                       ]]>
                     </message>
                     <link href="https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html" title="JDK Logging Documentation" />
-                    <link href="https://developers.redhat.com/quickstarts/eap/logging/" title="JBoss Logging Quickstart" />
+                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.4/html/configuration_guide/logging_with_jboss_eap" title="Logging with JBoss EAP" />
                     <tag>logging</tag>
                     <tag>weblogic</tag>
                 </hint>

--- a/rules/rules-reviewed/eap7/weblogic/weblogic.windup.xml
+++ b/rules/rules-reviewed/eap7/weblogic/weblogic.windup.xml
@@ -233,7 +233,7 @@
                       ]]>
                     </message>
                     <link href="https://docs.oracle.com/javase/7/docs/technotes/guides/logging/overview.html" title="JDK Logging Documentation" />
-                    <link href="https://developers.redhat.com/quickstarts/eap/logging/" title="JBoss Logging Quickstart" />
+                    <link href="https://access.redhat.com/documentation/en-us/red_hat_jboss_enterprise_application_platform/7.4/html/configuration_guide/logging_with_jboss_eap" title="Logging with JBoss EAP" />
                     <tag>logging</tag>
                     <tag>weblogic</tag>
                 </hint>


### PR DESCRIPTION
@m-brophy - 2 rules needed changing.
As we have rules for Weblogic to EAP6 and WebLogic to EAP7
The former need to be retired. I'll create a separate Jira for that.