### PR TITLE
WINDUPRULE-934 Added CDI Jakarta technology-tag

### DIFF
--- a/rules/rules-reviewed/technology-usage/embedded-framework-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/embedded-framework-technology-usage.windup.xml
@@ -560,20 +560,6 @@
                 </technology-identified>
             </perform>
         </rule>
-        <rule id="technology-usage-embedded-framework-05500">
-            <when>
-                <graph-query discriminator="TechnologyTagModel">
-                    <property name="name">CDI</property>
-                </graph-query>
-            </when>
-            <perform>
-                <technology-identified name="CDI">
-                    <tag name="Execute"/>
-                    <tag name="Embedded"/>
-                    <tag name="Inversion of Control"/>
-                </technology-identified>
-            </perform>
-        </rule>
         <rule id="technology-usage-embedded-framework-05600">
             <when>
                 <graph-query discriminator="TechnologyTagModel">

--- a/rules/rules-reviewed/technology-usage/javaee-technology-usage.windup.xml
+++ b/rules/rules-reviewed/technology-usage/javaee-technology-usage.windup.xml
@@ -63,11 +63,22 @@
             </perform>
         </rule>
         <!-- CDI packages references -->
-        <rule id="javaee-technology-usage-00020">
+        <rule id="javaee-technology-usage-00020-javax">
             <when>
                 <or>
                     <javaclass references="javax.enterprise.inject.{*}"/>
                     <javaclass references="javax.inject.{*}"/>
+                </or>
+            </when>
+            <perform>
+                <technology-tag level="INFORMATIONAL">CDI</technology-tag>
+            </perform>
+        </rule>
+        <rule id="javaee-technology-usage-00020-jakarta">
+            <when>
+                <or>
+                    <javaclass references="jakarta.enterprise.inject.{*}"/>
+                    <javaclass references="jakarta.inject.{*}"/>
                 </or>
             </when>
             <perform>
@@ -83,7 +94,7 @@
             <perform>
                 <technology-identified name="CDI">
                     <tag name="Execute"/>
-                    <tag name="Processing"/>
+                    <tag name="Inversion of Control"/>
                     <tag name="Java EE"/>
                 </technology-identified>
             </perform>

--- a/rules/rules-reviewed/technology-usage/tests/data/javaee/JsonControllerJakarta.java
+++ b/rules/rules-reviewed/technology-usage/tests/data/javaee/JsonControllerJakarta.java
@@ -1,0 +1,99 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015, Red Hat, Inc. and/or its affiliates, and individual
+ * contributors by the @authors tag. See the copyright.txt in the
+ * distribution for a full listing of individual contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//package org.jboss.as.quickstarts.jsonp;
+
+import java.io.StringReader;
+
+import jakarta.enterprise.inject.Model;
+import jakarta.faces.application.FacesMessage;
+import jakarta.faces.context.FacesContext;
+import jakarta.inject.Inject;
+import jakarta.json.Json;
+import jakarta.json.JsonException;
+import jakarta.json.stream.JsonParser;
+import jakarta.json.stream.JsonParser.Event;
+
+@Model
+public class JsonControllerJakarta {
+
+    @Inject
+    private Person person;
+
+    private String jsonString;
+
+    private String parsedResult;
+
+    public void generateJson() {
+        jsonString = Json.createObjectBuilder()
+            .add("name", person.getName())
+            .add("age", person.getAge())
+            .add("enabled", person.getEnabled())
+            .add("phones", Json.createArrayBuilder()
+                .add(person.getPhone1())
+                .add(person.getPhone2())
+            )
+            .add("addrees", Json.createObjectBuilder()
+                .add("street", person.getAddressStreet())
+                .add("apt", person.getAddressApt())
+                .add("city", person.getAddressCity())
+                .add("zip", person.getAddressZip())
+            )
+            .build().toString();
+    }
+
+    public void parseJsonStream() {
+        StringBuilder sb = new StringBuilder();
+        String json = getJsonString();
+        try {
+            JsonParser parser = Json.createParser(new StringReader(json));
+            while (parser.hasNext()) {
+                Event event = parser.next();
+                if (event.equals(Event.KEY_NAME)) {
+                    sb.append(" - - - -  >  Key: " + parser.getString() + "  < - - - - - \n");
+                }
+                if (event.equals(Event.VALUE_STRING)) {
+                    sb.append("Value as String: " + parser.getString() + "\n");
+                }
+                if (event.equals(Event.VALUE_NUMBER)) {
+                    sb.append("Value as Number: " + parser.getInt() + "\n");
+                }
+                if (event.equals(Event.VALUE_TRUE)) {
+                    sb.append("Value as Boolean: true\n");
+                }
+                if (event.equals(Event.VALUE_FALSE)) {
+                    sb.append("Value as Boolean: false \n");
+                }
+            }
+        } catch (JsonException e) {
+            FacesContext.getCurrentInstance().addMessage("form:parsed", new FacesMessage(e.getMessage()));
+        }
+        parsedResult = sb.toString();
+    }
+
+    public void setJsonString(String jsonString) {
+        this.jsonString = jsonString;
+    }
+
+    public String getJsonString() {
+        return jsonString;
+    }
+
+    public String getParsedResult() {
+        return parsedResult;
+    }
+
+}

--- a/rules/rules-reviewed/technology-usage/tests/embedded-framework-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/embedded-framework-technology-usage.windup.test.xml
@@ -560,20 +560,6 @@
                <fail message="Expected data not found for rule technology-usage-embedded-framework-05400"/>
             </perform>
          </rule>
-         <rule id="technology-usage-embedded-framework-05500-test">
-            <when>
-               <not>
-                  <technology-statistics-exists name="CDI" number-found="1">
-                     <tag name="Execute"/>
-                     <tag name="Embedded"/>
-                     <tag name="Inversion of Control"/>
-                  </technology-statistics-exists>
-               </not>
-            </when>
-            <perform>
-               <fail message="Expected data not found for rule technology-usage-embedded-framework-05500"/>
-            </perform>
-         </rule>
          <rule id="technology-usage-embedded-framework-05600-test">
             <when>
                <not>

--- a/rules/rules-reviewed/technology-usage/tests/javaee-technology-usage.windup.test.xml
+++ b/rules/rules-reviewed/technology-usage/tests/javaee-technology-usage.windup.test.xml
@@ -37,7 +37,7 @@
                     <not>
                         <technology-statistics-exists name="CDI" number-found="1">
                             <tag name="Execute"/>
-                            <tag name="Processing"/>
+                            <tag name="Inversion of Control"/>
                             <tag name="Java EE"/>
                         </technology-statistics-exists>
                     </not>


### PR DESCRIPTION
https://issues.redhat.com/browse/WINDUPRULE-934

- added Jakarta CDI identification rule
- removed duplicated `technology-usage-embedded-framework-05500`
- set CDI in the `Inversion of Control` box

PS: I've tried a lot for having just one rule covering both `javax` and `jakarta` root packages but it never worked as expected (I suspect due to [WINDUP-1324](https://issues.redhat.com/browse/WINDUP-1324).
The sample not-working rule I've tried with was (`hint` is there for the sake of having a quick feedback on reports):
```xml
        <rule id="javaee-technology-usage-00019">
            <when>
                <javaclass references="{ee-flavor}{enterprise}inject.{*}">
                    <location>IMPORT</location>
                </javaclass>
            </when>
            <perform>
                <hint title="found CDI" effort="13">
                    <message>found CDI in {ee-flavor}{enterprise}</message>
                </hint>
            </perform>
            <where param="ee-flavor">
                <matches pattern="(javax|jakarta)" />
            </where>
            <where param="enterprise">
                <matches pattern="(\.enterprise\.|\.)" />
            </where>
        </rule>
```