### PR TITLE
Changing name of same exact class to have different names

### DIFF
--- a/rules/rules-archived/eap6/websphere/tests/data/WebSphereJMSExample2.java
+++ b/rules/rules-archived/eap6/websphere/tests/data/WebSphereJMSExample2.java
@@ -33,7 +33,7 @@ import com.ibm.msg.client.jms.JmsXATopicSession;
 /**
  * Testing detection of com.ibm.websphere.sib.api.jms.JmsConnectionFactory
  */
-public class WebSphereJMSExample
+public class WebSphereJMSExample2
 {
     public static void main(String[] args) throws IOException, JMSException
     {

--- a/rules/rules-reviewed/eap7/websphere/tests/data/WebSphereJMSExample2.java
+++ b/rules/rules-reviewed/eap7/websphere/tests/data/WebSphereJMSExample2.java
@@ -33,7 +33,7 @@ import com.ibm.msg.client.jms.JmsXATopicSession;
 /**
  * Testing detection of com.ibm.websphere.sib.api.jms.JmsConnectionFactory
  */
-public class WebSphereJMSExample
+public class WebSphereJMSExample2
 {
     public static void main(String[] args) throws IOException, JMSException
     {


### PR DESCRIPTION
This is another small fix, that allows for the determining of correct information to be loaded during the web sphere tests.