### PR TITLE
WINDUPRULE-944 obsolete OracleJDK package

### DIFF
--- a/rules/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
+++ b/rules/rules-reviewed/openjdk7/oraclejdk7/oracle2openjdk.rhamt.xml
@@ -158,5 +158,26 @@
                 </hint>
             </perform>
         </rule>
+        <rule id="oracle2openjdk-00006">
+            <when>
+                <javaclass references="com.sun.image.codec.jpeg.{*}">
+                        <location>CONSTRUCTOR_CALL</location>
+                        <location>IMPORT</location>
+                        <location>INHERITANCE</location>
+                        <location>METHOD_CALL</location>
+                        <location>VARIABLE_DECLARATION</location>
+                </javaclass>
+            </when>
+            <perform>
+                <hint title="Oracle JDK JPEG image encoder/decoder usage" effort="3" category-id="mandatory">
+                    <message>
+                        Replace the use of classes and methods from the `com.sun.image.codec.jpeg` package with `javax.imageio.ImageIO` 
+                    </message>
+                    <link href="https://access.redhat.com/solutions/443673" title="java.lang.NoClassDefFoundError: com/sun/image/codec/jpeg/ImageFormatException when using OpenJDK" />
+                    <link href="https://docs.oracle.com/javase/tutorial/2d/images/saveimage.html" title="Java Image I/O tutorial" />
+                    <link href="https://docs.oracle.com/javase/8/docs/technotes/guides/imageio/spec/imageio_guideTOC.fm.html" title="Java Image I/O API Guide" />
+                </hint>
+            </perform>
+        </rule>
     </rules>
 </ruleset>

--- a/rules/rules-reviewed/openjdk7/oraclejdk7/tests/data/ImageEncoderTest.java
+++ b/rules/rules-reviewed/openjdk7/oraclejdk7/tests/data/ImageEncoderTest.java
@@ -1,0 +1,14 @@
+package com.acme;
+
+import com.sun.image.codec.jpeg.*;
+
+public class ImageEncoderTest {
+
+    public static void main(String[] args) {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+        JPEGImageEncoder imageEncoder = JPEGCodec.createJPEGEncoder(outputStream);
+        imageEncoder.encode(bufferedImage);
+
+
+}

--- a/rules/rules-reviewed/openjdk7/oraclejdk7/tests/oracle2openjdk.rhamt.test.xml
+++ b/rules/rules-reviewed/openjdk7/oraclejdk7/tests/oracle2openjdk.rhamt.test.xml
@@ -79,6 +79,18 @@
                     <fail message="[oracle2openjdk] elliptic curve hint not found" />
                 </perform>
             </rule>
+            <rule id="oracle2openjdk-00006-test">
+                <when>
+                    <not>
+                        <iterable-filter size="1">
+                            <hint-exists message="Replace the use of classes and methods from the `com.sun.image.codec.jpeg`"/>
+                        </iterable-filter>
+                    </not>
+                </when>
+                <perform>
+                    <fail message="oracle2openjdk-00006-test failed" />
+                </perform>
+            </rule>
         </rules>
     </ruleset>
 </ruletest>


### PR DESCRIPTION
Like the other ruleset in the ruleset without adding an additional classpath to a jar containing the obsolete oracle java classes the rules can actually only pick up the obsolete package in the import statements, rather than in the body of the test data java classes. 
The new rule is consistent with the other rules in the ruleset.    
We would need legal advice about adding those Oracle classes.
But because it is an aging ruleset, and the utility of it is diminishing over time, it is fit for purpose.