### PR TITLE
WindupRulesLinksTest job needs windup-build job

### DIFF
--- a/.github/workflows/pr_build_jdk11.yml
+++ b/.github/workflows/pr_build_jdk11.yml
@@ -72,6 +72,7 @@ jobs:
 
   WindupRulesLinksTest:
     runs-on: ubuntu-latest
+    needs: [windup-build]
     strategy:
         fail-fast: false
         matrix:
@@ -86,6 +87,13 @@ jobs:
           distribution: ${{ matrix.jdk-distribution }}
           java-package: jdk
           cache: 'maven'
+      - name: Cache local Maven repository
+        uses: actions/cache@v3
+        with:
+            path: ~/.m2/repository
+            key: ${{ runner.os }}-maven-windup-rulesets-build-${{ github.sha }}
+            restore-keys: |
+                ${{ runner.os }}-maven-windup-build-${{ github.sha }}
       - name: Build
         run: mvn -B clean install -DskipTests
       - name: Test


### PR DESCRIPTION
To avoid errors like `Non-resolvable import POM: Could not find artifact org.jboss.windup:windup-bom:pom:6.2.4-SNAPSHOT in sonatype-snapshots-repo (https://oss.sonatype.org/content/repositories/snapshots) @ line 85, column 25` in the backport PRs (e.g. https://github.com/windup/windup-rulesets/actions/runs/4891189140/jobs/8731390087?pr=943) also the `WindupRulesLinksTest` needs to wait for the `windup-build` job to build to leverage the cached artifacts