### PR TITLE
PostgreSQL technology: conditional hint for Azure targets

### DIFF
--- a/rules/rules-reviewed/technology-usage/database.windup.groovy
+++ b/rules/rules-reviewed/technology-usage/database.windup.groovy
@@ -6,7 +6,9 @@ import org.jboss.windup.graph.model.resource.FileModel
 import org.jboss.windup.graph.service.WindupConfigurationService
 import org.jboss.windup.project.condition.Artifact
 import org.jboss.windup.project.condition.Project
+import org.jboss.windup.reporting.category.IssueCategory
 import org.jboss.windup.reporting.category.IssueCategoryRegistry
+import org.jboss.windup.reporting.config.Hint
 import org.jboss.windup.reporting.config.Link
 import org.jboss.windup.reporting.config.classification.Classification
 import org.jboss.windup.reporting.model.TechnologyTagLevel
@@ -16,11 +18,20 @@ import org.jboss.windup.rules.files.condition.File
 import org.ocpsoft.rewrite.config.Or
 import org.ocpsoft.rewrite.context.EvaluationContext
 
+final IssueCategory potentialIssueCategory = new IssueCategoryRegistry().getByID(IssueCategoryRegistry.POTENTIAL)
+
 static boolean hasAnalysisTargetEap(GraphContext graphContext) {
     WindupConfigurationService.getConfigurationModel(graphContext)
         .getTargetTechnologies()
         .stream()
         .anyMatch { ("eap" == it.technologyID) }
+}
+
+static boolean hasAnalysisTargetAzure(GraphContext graphContext) {
+    WindupConfigurationService.getConfigurationModel(graphContext)
+        .getTargetTechnologies()
+        .stream()
+        .anyMatch { (it.technologyID.toLowerCase().contains("azure")) }
 }
 
 static void perform(GraphRewrite event, EvaluationContext context, FileModel fileModel, String technology, boolean withLink) {
@@ -71,6 +82,16 @@ ruleSet("database")
     .perform(new AbstractIterationOperation<FileLocationModel>() {
         void perform(GraphRewrite event, EvaluationContext context, FileLocationModel payload) {
             perform(event, context, payload.getFile(), "PostgreSQL Driver", true)
+            if (hasAnalysisTargetAzure(event.graphContext)) {
+                final Hint hint = Hint.titled("PostgreSQL database found")
+                .withText("""PostgreSQL database found.  
+                        Consider using Azure PostgreSQL Flexible Server.""")
+                .withIssueCategory(potentialIssueCategory)
+                .with(Link.to("Azure Database for PostgreSQL", "https://azure.microsoft.com/products/postgresql"))
+                .with(Link.to("Flexible Server documentation", "https://learn.microsoft.com/azure/postgresql/flexible-server"))
+                .withEffort(3)
+                hint.perform(event, context, payload)
+            }
         }
     })
     .withId(String.format("database-0%d00", id++))

--- a/rules/rules-reviewed/technology-usage/database.windup.groovy
+++ b/rules/rules-reviewed/technology-usage/database.windup.groovy
@@ -44,7 +44,11 @@ static void perform(GraphRewrite event, EvaluationContext context, FileModel fil
         classification.with(Link.to("Red Hat JBoss Enterprise Application Platform (EAP) 7 Supported Configurations", "https://access.redhat.com/articles/2026253"))
     }
     classification.performParameterized(event, context, fileModel)
-    final TechnologyTagService technologyTagService = new TechnologyTagService(event.getGraphContext())
+    addTagToFileModel(event.getGraphContext(), fileModel, technology)
+}
+
+static void addTagToFileModel(GraphContext graphContext, FileModel fileModel, String technology) {
+    final TechnologyTagService technologyTagService = new TechnologyTagService(graphContext)
     technologyTagService.addTagToFileModel(fileModel, "$technology", TechnologyTagLevel.INFORMATIONAL)
 }
 
@@ -81,7 +85,8 @@ ruleSet("database")
     .when(File.inFileNamed("{*}postgresql{*}.jar"))
     .perform(new AbstractIterationOperation<FileLocationModel>() {
         void perform(GraphRewrite event, EvaluationContext context, FileLocationModel payload) {
-            perform(event, context, payload.getFile(), "PostgreSQL Driver", true)
+            final FileModel fileModel = payload.getFile()
+            final String technology = "PostgreSQL Driver"
             if (hasAnalysisTargetAzure(event.graphContext)) {
                 final Hint hint = Hint.titled("PostgreSQL database found")
                 .withText("""PostgreSQL database found.  
@@ -91,6 +96,9 @@ ruleSet("database")
                 .with(Link.to("Flexible Server documentation", "https://learn.microsoft.com/azure/postgresql/flexible-server"))
                 .withEffort(3)
                 hint.perform(event, context, payload)
+                addTagToFileModel(event.getGraphContext(), fileModel, technology)
+            } else {
+                perform(event, context, fileModel, technology, true)
             }
         }
     })


### PR DESCRIPTION
Alternative implementation for https://github.com/Azure/windup-rulesets/pull/39

When an Azure related targets is selected a further hint is added to the analysis with SPs and Category.
The classification is still there since it's just an information with 0 SP so it doesn't affect the effort involved in migrating.

Sample of analysis without and with a Azure target:
![Screenshot from 2023-05-30 17-01-09](https://github.com/windup/windup-rulesets/assets/7288588/42203b79-9a57-4714-a2c5-7f54cee93fd8)

@agoncal WDYT?