### PR TITLE
Refactored test output folder name

### DIFF
--- a/rules/src/test/java/org/jboss/windup/rules/tests/RuleTest.java
+++ b/rules/src/test/java/org/jboss/windup/rules/tests/RuleTest.java
@@ -13,11 +13,26 @@ import java.util.List;
  */
 public class RuleTest
 {
+    private String id;
     private String testDataPath;
     private List<String> rulePaths = new ArrayList<>();
     private List<String> ruleIds = new ArrayList<>();
     private String source;
     private String target;
+
+    /**
+     * Gets the ruletest ID
+     */
+    public String getId() {
+        return id;
+    }
+
+    /**
+     * Sets the ruletest ID
+     */
+    public void setId(String id) {
+        this.id = id;
+    }
 
     /**
      * Gets the source technology to operate on (eg, Glassfish).

--- a/rules/src/test/java/org/jboss/windup/rules/tests/RuleTestHandler.java
+++ b/rules/src/test/java/org/jboss/windup/rules/tests/RuleTestHandler.java
@@ -51,6 +51,7 @@ import org.w3c.dom.Element;
 public class RuleTestHandler implements ElementHandler<RuleTest>
 {
     public static final String RULETEST = "ruletest";
+    public static final String RULETEST_ID = "id";
     public static final String TEST_DATA_PATH = "testDataPath";
     public static final String RULE_PATH = "rulePath";
     public static final String SOURCE_MODE = "sourceMode";
@@ -62,6 +63,7 @@ public class RuleTestHandler implements ElementHandler<RuleTest>
     public RuleTest processElement(ParserContext context, Element element) throws ConfigurationException
     {
         RuleTest ruleTest = new RuleTest();
+        ruleTest.setId($(element).attr(RULETEST_ID));
 
         List<Element> children = $(element).children().get();
         for (Element child : children)

--- a/rules/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
+++ b/rules/src/test/java/org/jboss/windup/rules/tests/WindupRulesTest.java
@@ -187,11 +187,11 @@ public class WindupRulesTest
             try
             {
                 Map<String, Exception> exceptions;
-                Path outputPath = getDefaultPath();
+                // load the ruletest file
+                final RuleTest ruleTest = parser.processDocument(ruleTestFile.toURI());
+                Path outputPath = getDefaultPath(ruleTest.getId());
                 try (GraphContext context = factory.create(outputPath, true))
                 {
-                    // load the ruletest file
-                    RuleTest ruleTest = parser.processDocument(ruleTestFile.toURI());
                     List<Path> rulePaths = new ArrayList<>();
                     if (ruleTest.getRulePaths().isEmpty())
                     {
@@ -316,9 +316,9 @@ public class WindupRulesTest
         return evaluationContext;
     }
 
-    private Path getDefaultPath()
+    private Path getDefaultPath(String rulesetId)
     {
-        return FileUtils.getTempDirectory().toPath().resolve("WindupRulesTests").resolve("windupgraph_" + RandomStringUtils.randomAlphanumeric(6));
+        return FileUtils.getTempDirectory().toPath().resolve("WindupRulesTests").resolve("windupgraph_" + rulesetId + "_" + RandomStringUtils.randomAlphanumeric(6));
     }
 
     private void runWindup(GraphContext context, File baseRuleDirectory, final List<Path> rulePaths, File input, File output, boolean sourceMode, String source, String target) throws IOException


### PR DESCRIPTION
Based on @agoncal's report about rules tests execution:

> Sometimes when you run tests matching a short word (eg. mvn clean test -DrunTestsMatching=web) you end up with several reports under target . Then, to find the appropriate one is quite difficult, You need to browse through all of them. When you open the report, most of the reports are named data, but not all of them.

which is reflected in the next screenshot 
![Screenshot 2023-06-21 at 15 12 17](https://github.com/windup/windup-rulesets/assets/7288588/b5eba08e-6b4d-46b1-8116-9ade5d7178d4)

with the changes in this PR, the same tests execution will create this folders structure:
![Screenshot from 2023-06-21 16-21-57](https://github.com/windup/windup-rulesets/assets/7288588/2e281b44-4b26-4052-8a67-21b2bcf2e4f7)
