### PR TITLE
Update broken links in OpenJDK rules

### DIFF
--- a/rules/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
+++ b/rules/rules-reviewed/openjdk11/openjdk8/java-removals.windup.xml
@@ -47,7 +47,8 @@
                         As such, the use of `sun.reflect.Reflection` class and particular the `getCallerClass` method should no longer be needed. 
                         Refer to the example changeset linked below.
                     </message>
-                    <link title="Example changeset" href="https://hg.openjdk.java.net/openjfx/9-dev/rt/rev/70f6fa01a32c"/>
+                    <link title="Example changeset" href="https://github.com/openjdk/jfx/commit/d647521fa83f0cebe9532642ee97ffc4356c8bb3"/>
+                    <link title="JDK-8154203" href="https://bugs.openjdk.org/browse/JDK-8154203"/>
                 </hint>
             </perform>
         </rule>
@@ -64,7 +65,8 @@
                         `sun.reflect.CallerSensitive` annotation was deprecated in Java 9.
                         Refer to the example changeset linked below. 
                     </message>
-                    <link title="Example changeset" href="https://hg.openjdk.java.net/openjfx/9-dev/rt/rev/70f6fa01a32c"/>
+                    <link title="Example changeset" href="https://github.com/openjdk/jfx/commit/d647521fa83f0cebe9532642ee97ffc4356c8bb3"/>
+                    <link title="JDK-8154203" href="https://bugs.openjdk.org/browse/JDK-8154203"/>
                 </hint>
             </perform>
         </rule>
@@ -196,7 +198,8 @@
 
                         In the long term, please consider using Variable Handles (see the link below)
                     </message>
-                    <link href="https://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/0a0a0986400e#l2.19" title="Test changes for JDK-8054494"/>
+                    <link href="https://bugs.openjdk.org/browse/JDK-8054494" title="JDK-8054494"/>
+                    <link href="https://github.com/openjdk/jdk/commit/083d9a2b6145a422bad64423675660c94bb32958#diff-12d7d73c9a167ec9451fe5e53373574adc02d9179cab3465e096a07d1aa79fc7" title="Test changes for JDK-8054494"/>
                     <link href="https://openjdk.java.net/jeps/193" title="Variable Handles"/>
                 </hint>
             </perform>
@@ -216,7 +219,8 @@
                         For further examples on how to replace the `BASE64{encoder-decoder}` class with `Base64.{encoder-decoder}` one, refer to the "Code example" link below.  
                     </message>
                     <link title="java.util.Base64 - Javadoc" href="https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/util/Base64.html"/>
-                    <link title="Code example" href="https://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/9078c34437ab"/>
+                    <link title="JDK-8006182" href="https://bugs.openjdk.org/browse/JDK-8006182"/>
+                    <link title="Code example" href="https://github.com/openjdk/jdk/commit/ec9e303630158405d0faaabb74f466f0a376c1fc"/>
                     <link title="OpenJDK - Original enhancement request" href="https://bugs.openjdk.java.net/browse/JDK-8006182"/>
                 </hint>
             </perform>


### PR DESCRIPTION
These are broken links:

- https://hg.openjdk.java.net/openjfx/9-dev/rt/rev/70f6fa01a32c
- https://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/0a0a0986400e#l2.19
- https://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/9078c34437ab

As reported in https://www.mail-archive.com/web-discuss@openjdk.org/msg00008.html: 
> The sources on hg.openjdk.org are severely outdated and the server is only kept around for reference. We have migrated all relevant repositories to GitHub and that is now our preferred hosting solution.

So I've tried to find the same commits in GitHub OpenJDK repositories.
In order to achieve it, I've searched for the OpenJDK's bugs the commits referenced in the broken links above were fixing and, using the bug ID, I've searched the related commits in  OpenJDK's repositories and replaced the broken links with the working ones:

- https://hg.openjdk.java.net/openjfx/9-dev/rt/rev/70f6fa01a32c => [JDK-8154203](https://bugs.openjdk.org/browse/JDK-8154203) => [d647521fa83f0cebe9532642ee97ffc4356c8bb3](https://github.com/openjdk/jfx/commit/d647521fa83f0cebe9532642ee97ffc4356c8bb3)
- https://hg.openjdk.java.net/jdk9/jdk9/jdk/rev/0a0a0986400e#l2.19 => [JDK-8054494](https://bugs.openjdk.org/browse/JDK-8054494) => [083d9a2b6145a422bad64423675660c94bb32958](https://github.com/openjdk/jdk/commit/083d9a2b6145a422bad64423675660c94bb32958#diff-12d7d73c9a167ec9451fe5e53373574adc02d9179cab3465e096a07d1aa79fc7)
- https://hg.openjdk.java.net/jdk8/jdk8/jdk/rev/9078c34437ab => [JDK-8006182](https://bugs.openjdk.org/browse/JDK-8006182) => [ec9e303630158405d0faaabb74f466f0a376c1fc](https://github.com/openjdk/jdk/commit/ec9e303630158405d0faaabb74f466f0a376c1fc)

I've also took the chance to add, for each new link, the OpenJDK Bug it refers to.

CC @neugens