### PR TITLE
Package OpenRewrite recipes as jar

### DIFF
--- a/rules/pom.xml
+++ b/rules/pom.xml
@@ -384,6 +384,25 @@
                   </includes>
                </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>generate-openrewrite-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/main/assembly/rewrite.xml</descriptor>
+                            </descriptors>
+                            <appendAssemblyId>true</appendAssemblyId>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
             <!--
             we need to download the CSS files each time we generate the surefire report due to
             https://issues.apache.org/jira/browse/SUREFIRE-616

--- a/rules/src/main/assembly/rewrite.xml
+++ b/rules/src/main/assembly/rewrite.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.1.1"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.1.1 https://maven.apache.org/xsd/assembly-2.1.1.xsd">
+  <id>rewrite</id>
+  <formats>
+    <format>jar</format>
+  </formats>
+  <includeBaseDirectory>false</includeBaseDirectory>
+  <fileSets>
+    <fileSet>
+      <directory>rules-reviewed/openrewrite</directory>
+      <includes>
+        <include>**/*.yaml</include>
+        <include>**/*.yml</include>
+      </includes>
+      <outputDirectory>META-INF/rewrite</outputDirectory>
+    </fileSet>
+  </fileSets>
+</assembly>


### PR DESCRIPTION
This is a contribution to https://issues.redhat.com/browse/WINDUPRULE-1046 
It enables to use the following plugin configuration in `pom.xml`
```
            <plugin>
                <groupId>org.openrewrite.maven</groupId>
                <artifactId>rewrite-maven-plugin</artifactId>
                <version>5.17.1</version>
                <dependencies>
                    <dependency>
                        <groupId>org.jboss.windup.rules</groupId>
                        <artifactId>windup-rulesets</artifactId>
                        <classifier>rewrite</classifier>
                        <version>6.4.0-SNAPSHOT</version>
                    </dependency>
                </dependencies>
            </plugin>
```
and then e.g:
```
mvn rewrite:discover | grep windup
[INFO]     org.jboss.windup.eap8.FacesWebXml
[INFO]     org.jboss.windup.jakarta.javax.BootstrappingFiles
[INFO]     org.jboss.windup.jakarta.javax.PersistenceXml
[INFO]     org.jboss.windup.JavaxActivationToJakartaActivation
[INFO]     org.jboss.windup.JavaxAnnotationToJakartaAnnotation
[INFO]     org.jboss.windup.JavaxBatchToJakartaBatch
[INFO]     org.jboss.windup.JavaxDecoratorToJakartaDecorator
[INFO]     org.jboss.windup.JavaxEjbToJakartaEjb
[INFO]     org.jboss.windup.JavaxElToJakartaEl
```
The code is taken from https://github.com/quarkusio/quarkus-updates/blob/main/recipes/pom.xml and https://github.com/quarkusio/quarkus-updates/blob/main/recipes/src/main/assembly/core.xml

This is meant as proof of concept and does not fix WINDUPRULE-1046
One problem is, that `windup-cli --openrewrite` uses `-Drewrite.recipeArtifactCoordinates` but this option apparently doesn't understand maven classifiers.
Also it might not be the best solution to generate a separate artifact instead of just moving the `rewrite.yml` files to `META-INF/rewrite`. However that would have more impact, while this change is compatible with older versions.